### PR TITLE
Move rewards required value to settings

### DIFF
--- a/config/demo-settings.yml
+++ b/config/demo-settings.yml
@@ -55,6 +55,10 @@ url:
     #
     data:
 
+# Default required rewards
+rewards:
+    required: 3
+
 # PLUGINS
 # Extend is the directory to personalize your copy of goteo.org
 # Routes, classes and templates can be overridden by copying the main structure

--- a/config/vagrant-settings.yml
+++ b/config/vagrant-settings.yml
@@ -55,6 +55,10 @@ url:
     #
     data:
 
+# Default required rewards
+rewards:
+    required: 3
+
 # PLUGINS
 # Extend is the directory to personalize your copy of goteo.org
 # Routes, classes and templates can be overridden by copying the main structure

--- a/src/Goteo/Model/Project.php
+++ b/src/Goteo/Model/Project.php
@@ -2506,9 +2506,11 @@ namespace Goteo\Model {
             } else {
                 $res->rewards = 100;
             }
-            if($total < 3) {
+            // rewards required >= 1, default 3
+            $rewards_required = abs(intval(Config::get('rewards.required'))) ?: 3;
+            if($total < $rewards_required) {
                 $errors['rewards'][] = 'rewards_required';
-                $res->rewards *= $total / 3;
+                $res->rewards *= $total / $rewards_required;
             }
 
             $campaign = [ ];


### PR DESCRIPTION
Even though 3 seems a fair value as the required amount of rewards
for any given project, it is better to set that value through the
global settings than having it hardcoded.

The former default is preserved if the settings value is not found.