### PR TITLE
Override method idealiza inside User class

### DIFF
--- a/src/Goteo/Model/User.php
+++ b/src/Goteo/Model/User.php
@@ -70,6 +70,11 @@ class User extends \Goteo\Core\Model {
     $webs = array(),
     $roles = array();
 
+    // Cambia el valor por defecto de $punto solo para la clase User
+    public static function idealiza($value, $punto = true, $enye = false, $max = 50) {
+        return parent::idealiza($value, $punto, $enye, $max);
+    }
+
     public function __construct() {
         $args = func_get_args();
         call_user_func_array(array('parent', '__construct'), $args);
@@ -140,7 +145,7 @@ class User extends \Goteo\Core\Model {
             // Nuevo usuario.
             if (empty($this->id)) {
                 $insert = true;
-                $this->id = static::idealiza($this->userid, true);
+                $this->id = static::idealiza($this->userid);
                 $data[':id'] = $this->id;
                 $data[':name'] = $this->name;
                 $data[':location'] = $this->location;
@@ -344,7 +349,7 @@ class User extends \Goteo\Core\Model {
             if (empty($this->userid)) {
                 $errors['userid'] = Text::get('error-register-userid');
             } else {
-                $id = self::idealiza($this->userid, true);
+                $id = self::idealiza($this->userid);
                 $query = self::query('SELECT id FROM user WHERE id = ?', array($id));
                 if ($query->fetchColumn()) {
                     $errors['userid'] = Text::get('error-register-user-exists'). " ($id)";
@@ -2341,7 +2346,7 @@ class User extends \Goteo\Core\Model {
             $parts = preg_split("/[\s,\-\@\.]+/", $string);
             $id = '';
             foreach($parts as $part) {
-                $id .= self::idealiza($part, true);
+                $id .= self::idealiza($part);
                 if(strlen($id) < 4) continue;
                 if($id) {
                     $originals[] = $id;

--- a/tests/Goteo/Model/UserTest.php
+++ b/tests/Goteo/Model/UserTest.php
@@ -5,6 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\TestCase;
 use Goteo\Model\User;
+use Goteo\Core\Model;
 
 class UserTest extends TestCase {
     private static $related_tables = array('user_api' => 'user_id',
@@ -93,8 +94,10 @@ class UserTest extends TestCase {
         $suggestions = User::suggestUserId("IHopeThisUserDoesNotexists:👑");
         $this->assertEquals('ihopethisuserdoesnotexists', $suggestions[0]);
 
-        $this->assertEquals('a-n', User::idealiza("a.ñ"));
+        // $punto is false in Model but true in User by default
+        $this->assertEquals('a-n', Model::idealiza("a.ñ"));
         $this->assertEquals('a.n', User::idealiza("a.ñ", true));
+        $this->assertEquals('a.n', User::idealiza("a.ñ"));
         $this->assertEquals('a.ñ', User::idealiza("a.ñ", true, true));
     }
 


### PR DESCRIPTION
A new call to idealiza with default values was added after merging https://github.com/GoteoFoundation/goteo/pull/97 disabling dots asvalid characters for username in that call (see commit f13c844d3).

This change will make the default value of `$punto` to be true for all existing and future calls inside User class.