### PR TITLE
agregada la libreria Snowplow\RefererParser en composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
         "symfony/security-csrf": "2.8",
         "symfony/validator": "2.8",
         "kohkimakimoto/lib-migration": "^1.2",
-        "sensiolabs/ansi-to-html": "^1.1"
+        "sensiolabs/ansi-to-html": "^1.1",
+        "snowplow/referer-parser": "0.2.0"
 
     },
 


### PR DESCRIPTION
Cuando instalas el proyecto tira el siguiente error porque falta instalar el paquete snowplow/referer-parser

Fatal error: Uncaught Error: Class 'Snowplow\RefererParser\Parser' not found in ~/src/Goteo/Util/Origins/Parser.php:66