### PR TITLE
Dockerfile set grunt-cli@1.3.2

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -18,7 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 RUN gem install sass -v 3.4.23
 RUN gem install compass
-RUN npm install -g grunt-cli
+RUN npm install -g grunt-cli@1.3.2
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 # PHP-FPM packages need a nudge to make them docker-friendly


### PR DESCRIPTION
This PR will set the grunt-cli version in the Dockerfile to 1.3.2 so that it does not brake with node versions smaller than 8 ([grunt-cli@1.4.0](https://github.com/gruntjs/grunt-cli/compare/v1.3.2...v1.4.0)) or 10 ([grunt-cli@1.4.2](https://github.com/gruntjs/grunt-cli/compare/v1.4.0...v1.4.2))