### PR TITLE
Added (un)zip packages to Dockerfile so we remove Composer warning

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -11,6 +11,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y --no-install-recommends install php7.1-fpm \
     && apt-get -y --no-install-recommends install php-memcached php7.1-mysql php7.1-gd php-xdebug \
     && apt-get -y --no-install-recommends install nodejs npm build-essential ruby-dev rubygems-integration gosu \
+    && apt-get -y install zip unzip \
     && apt-get -y install mysql-client \
     && apt-get -y install jq \
     && apt-get clean \


### PR DESCRIPTION
When performing a `composer install`, the following warning is displayed:

> As there is no 'unzip' command installed zip files are being unpacked using the PHP zip extension.
> This may cause invalid reports of corrupted archives. Besides, any UNIX permissions (e.g. executable) defined in the archives will be lost.
> Installing 'unzip' may remediate them.

By adding zip/unzip packages in the Dockerfile the alert will be gone, and we could save us some future troubles.