### PR TITLE
Update composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
         "php": "^7.0",
         "foil/foil": "~0.6",
         "tpyo/amazon-s3-php-class": "~0.5",
-        "phpmailer/phpmailer": "~5.2",
+        "phpmailer/phpmailer": "^6.0",
         "jdorn/file-system-cache": "dev-master",
         "intervention/image": "~2.0",
         "mibe/feedwriter": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "unreal4u/telegram-api": "~3.4",
         "spipu/html2pdf": "^5.2",
         "snowplow/referer-parser": "0.2.0",
-        "ext-pdo": "*"
+        "ext-pdo": "*",
+        "ext-openssl": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "php": "^7.0",
         "foil/foil": "~0.6",
-        "tpyo/amazon-s3-php-class": "~0.5",
+        "tpyo/amazon-s3-php-class": "dev-master#81a35c61bf76be7c02c95a57771031d21277b1b5",
         "phpmailer/phpmailer": "^6.0",
         "jdorn/file-system-cache": "dev-master",
         "intervention/image": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "spipu/html2pdf": "^5.2",
         "snowplow/referer-parser": "0.2.0",
         "ext-pdo": "*",
-        "ext-openssl": "*"
+        "ext-openssl": "*",
+        "symfony/yaml": "^3.3"
     },
     "autoload": {
         "psr-4": {
@@ -58,7 +59,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "^6.0",
         "guzzle/plugin-mock": "~3.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
     "require": {
         "php": "^7.0",
+        "ext-pdo": "*",
+        "ext-openssl": "*",
         "foil/foil": "~0.6",
         "tpyo/amazon-s3-php-class": "dev-master#81a35c61bf76be7c02c95a57771031d21277b1b5",
         "phpmailer/phpmailer": "^6.4",
@@ -49,8 +51,6 @@
         "unreal4u/telegram-api": "~3.4",
         "spipu/html2pdf": "^5.2",
         "snowplow/referer-parser": "0.2.0",
-        "ext-pdo": "*",
-        "ext-openssl": "*",
         "symfony/yaml": "^3.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "gregwar/captcha": "^1.1",
         "geoip2/geoip2": "~2.0",
         "openclerk/country-list": "^1.0",
-        "mockery/mockery": "^0.9.4",
+        "mockery/mockery": "^1.0",
         "cron/cron": "1.0.*@dev",
         "bramus/monolog-colored-line-formatter": "~2.0",
         "setasign/fpdf": ">=1.8.1",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
         "php": "^7.0",
         "foil/foil": "~0.6",
         "tpyo/amazon-s3-php-class": "dev-master#81a35c61bf76be7c02c95a57771031d21277b1b5",
-        "phpmailer/phpmailer": "^6.0",
+        "phpmailer/phpmailer": "^6.4",
         "jdorn/file-system-cache": "dev-master",
         "intervention/image": "~2.0",
         "mibe/feedwriter": "~1.0",

--- a/src/Goteo/Model/Mail.php
+++ b/src/Goteo/Model/Mail.php
@@ -21,7 +21,7 @@ use Goteo\Model\Mail\StatsCollector;
 use Goteo\Model\Message as Comment;
 use Goteo\Util\Monolog\Processor\WebProcessor;
 use PDOException;
-use PHPMailer;
+use PHPMailer\PHPMailer\PHPMailer;
 
 class Mail extends Model {
     protected $Table = 'mail';

--- a/src/Goteo/TestCase.php
+++ b/src/Goteo/TestCase.php
@@ -16,7 +16,7 @@ namespace Goteo;
  *
  * @author Juan Treminio <jtreminio@gmail.com>
  */
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/Goteo/Application/ConfigTest.php
+++ b/tests/Goteo/Application/ConfigTest.php
@@ -8,7 +8,7 @@ use Goteo\Application\Lang;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase {
+class ConfigTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Application/CookieTest.php
+++ b/tests/Goteo/Application/CookieTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Application\Tests;
 
 use Goteo\Application\Cookie;
 
-class CookieTest extends \PHPUnit_Framework_TestCase {
+class CookieTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Application/CurrencyTest.php
+++ b/tests/Goteo/Application/CurrencyTest.php
@@ -6,7 +6,7 @@ namespace Goteo\Application\Tests;
 use Goteo\Application\Currency;
 use Goteo\Application\Session;
 
-class CurrencyTest extends \PHPUnit_Framework_TestCase {
+class CurrencyTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Application/LangTest.php
+++ b/tests/Goteo/Application/LangTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Application\Tests;
 
 use Goteo\Application\Lang;
 
-class LangTest extends \PHPUnit_Framework_TestCase {
+class LangTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Application/MessageTest.php
+++ b/tests/Goteo/Application/MessageTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Application\Message;
 
-class MessageTest extends \PHPUnit_Framework_TestCase {
+class MessageTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Application/RoleTest.php
+++ b/tests/Goteo/Application/RoleTest.php
@@ -4,7 +4,7 @@ namespace Goteo\Application\Tests;
 
 use Goteo\Application\Role;
 
-class RoleTest extends \PHPUnit_Framework_TestCase {
+class RoleTest extends \PHPUnit\Framework\TestCase {
 
 	public function testInstance() {
 

--- a/tests/Goteo/Application/SessionTest.php
+++ b/tests/Goteo/Application/SessionTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Application\Tests;
 
 use Goteo\Application\Session;
 
-class SessionTest extends \PHPUnit_Framework_TestCase {
+class SessionTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Application/ViewTest.php
+++ b/tests/Goteo/Application/ViewTest.php
@@ -7,7 +7,7 @@ use Goteo\Application\View;
 use Goteo\Model\Project;
 use Goteo\Model\User;
 
-class ViewTest extends \PHPUnit_Framework_TestCase {
+class ViewTest extends \PHPUnit\Framework\TestCase {
     private static $views;
 
     static function setUpBeforeClass() {

--- a/tests/Goteo/Console/Command/DbVerifierCommandTest.php
+++ b/tests/Goteo/Console/Command/DbVerifierCommandTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Command\Tests;
 
 use Goteo\Console\Command\DBVerifierCommand;
 
-class DbVerifierCommandTest extends \PHPUnit_Framework_TestCase {
+class DbVerifierCommandTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Console/Command/ProjectWatcherCommandTest.php
+++ b/tests/Goteo/Console/Command/ProjectWatcherCommandTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Command\Tests;
 
 use Goteo\Console\Command\ProjectWatcherCommand;
 
-class ProjectWatcherCommandTest extends \PHPUnit_Framework_TestCase {
+class ProjectWatcherCommandTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Console/Command/TranslationsCommandTest.php
+++ b/tests/Goteo/Console/Command/TranslationsCommandTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Command\Tests;
 
 use Goteo\Console\Command\TranslationsCommand;
 
-class TranslationsCommandTest extends \PHPUnit_Framework_TestCase {
+class TranslationsCommandTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/AboutControllerTest.php
+++ b/tests/Goteo/Controller/AboutControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\AboutController;
 
-class AboutControllerTest extends \PHPUnit_Framework_TestCase {
+class AboutControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/Admin/AccountsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/AccountsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\AccountsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class AccountsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class AccountsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/BannersSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/BannersSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\BannersSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class BannersSubControllerTest extends \PHPUnit_Framework_TestCase {
+class BannersSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/BlogSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/BlogSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\BlogSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class BlogSubControllerTest extends \PHPUnit_Framework_TestCase {
+class BlogSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/CategoriesSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/CategoriesSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\CategoriesSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class CategoriesSubControllerTest extends \PHPUnit_Framework_TestCase {
+class CategoriesSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/CommonsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/CommonsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\CommonsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class CommonsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class CommonsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/CriteriaSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/CriteriaSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\CriteriaSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class CriteriaSubControllerTest extends \PHPUnit_Framework_TestCase {
+class CriteriaSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/FaqSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/FaqSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\FaqSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class FaqSubControllerTest extends \PHPUnit_Framework_TestCase {
+class FaqSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/FooterSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/FooterSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\FooterSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class FooterSubControllerTest extends \PHPUnit_Framework_TestCase {
+class FooterSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/GlossarySubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/GlossarySubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\GlossarySubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class GlossarySubControllerTest extends \PHPUnit_Framework_TestCase {
+class GlossarySubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/HomeSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/HomeSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\HomeSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class HomeSubControllerTest extends \PHPUnit_Framework_TestCase {
+class HomeSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/IconsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/IconsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\IconsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class IconsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class IconsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/InfoSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/InfoSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\InfoSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class InfoSubControllerTest extends \PHPUnit_Framework_TestCase {
+class InfoSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/LicencesSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/LicencesSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\LicensesSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class LicensesSubControllerTest extends \PHPUnit_Framework_TestCase {
+class LicensesSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/MailingSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/MailingSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\MailingSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class MailingSubControllerTest extends \PHPUnit_Framework_TestCase {
+class MailingSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/NewsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/NewsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\NewsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class NewsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class NewsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/NewsletterSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/NewsletterSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\NewsletterSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class NewsletterSubControllerTest extends \PHPUnit_Framework_TestCase {
+class NewsletterSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/NodeSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/NodeSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\NodeSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class NodeSubControllerTest extends \PHPUnit_Framework_TestCase {
+class NodeSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/NodesSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/NodesSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\NodesSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class NodesSubControllerTest extends \PHPUnit_Framework_TestCase {
+class NodesSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/OpenTagsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/OpenTagsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\OpenTagsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class OpenTagsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class OpenTagsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/PagesSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/PagesSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\PagesSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class PagesSubControllerTest extends \PHPUnit_Framework_TestCase {
+class PagesSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/PostsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/PostsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\PostsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class PostsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class PostsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/ProjectsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/ProjectsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\ProjectsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class ProjectsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class ProjectsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/PromoteSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/PromoteSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\PromoteSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class PromoteSubControllerTest extends \PHPUnit_Framework_TestCase {
+class PromoteSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/RecentSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/RecentSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\RecentSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class RecentSubControllerTest extends \PHPUnit_Framework_TestCase {
+class RecentSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/ReviewsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/ReviewsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\ReviewsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class ReviewsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class ReviewsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/RewardsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/RewardsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\RewardsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class RewardsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class RewardsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/SentSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/SentSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\SentSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class SentSubControllerTest extends \PHPUnit_Framework_TestCase {
+class SentSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/SponsorsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/SponsorsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\SponsorsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class SponsorsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class SponsorsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/StoriesSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/StoriesSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\StoriesSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class StoriesSubControllerTest extends \PHPUnit_Framework_TestCase {
+class StoriesSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/TagsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/TagsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\TagsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class TagsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class TagsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/TemplatesSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/TemplatesSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\TemplatesSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class TemplatesSubControllerTest extends \PHPUnit_Framework_TestCase {
+class TemplatesSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/TextsSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/TextsSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\TextsSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class TextsSubControllerTest extends \PHPUnit_Framework_TestCase {
+class TextsSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/TranslatesSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/TranslatesSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\TranslatesSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class TranslatesSubControllerTest extends \PHPUnit_Framework_TestCase {
+class TranslatesSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/TransnodesSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/TransnodesSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\TransnodesSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class TransnodesSubControllerTest extends \PHPUnit_Framework_TestCase {
+class TransnodesSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/UsersSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/UsersSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\UsersSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class UsersSubControllerTest extends \PHPUnit_Framework_TestCase {
+class UsersSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/WordcountSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/WordcountSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\WordcountSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class WordcountSubControllerTest extends \PHPUnit_Framework_TestCase {
+class WordcountSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/Admin/WorthSubControllerTest.php
+++ b/tests/Goteo/Controller/Admin/WorthSubControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Controller\Admin\WorthSubController;
 use Goteo\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 
-class WorthSubControllerTest extends \PHPUnit_Framework_TestCase {
+class WorthSubControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         $user = new User();

--- a/tests/Goteo/Controller/AdminControllerTest.php
+++ b/tests/Goteo/Controller/AdminControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\AdminController;
 
-class AdminControllerTest extends \PHPUnit_Framework_TestCase {
+class AdminControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/BlogControllerTest.php
+++ b/tests/Goteo/Controller/BlogControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\BlogController;
 
-class BlogControllerTest extends \PHPUnit_Framework_TestCase {
+class BlogControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/C7feb7803386d713e60894036feeee9eTest.php
+++ b/tests/Goteo/Controller/C7feb7803386d713e60894036feeee9eTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\C7feb7803386d713e60894036feeee9e;
 
-class C7feb7803386d713e60894036feeee9eTest extends \PHPUnit_Framework_TestCase {
+class C7feb7803386d713e60894036feeee9eTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/CommunityTest.php
+++ b/tests/Goteo/Controller/CommunityTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\Community;
 
-class CommunityTest extends \PHPUnit_Framework_TestCase {
+class CommunityTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/ContactControllerTest.php
+++ b/tests/Goteo/Controller/ContactControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\ContactController;
 
-class ContactControllerTest extends \PHPUnit_Framework_TestCase {
+class ContactControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/Dashboard/AjaxDashboardControllerTest.php
+++ b/tests/Goteo/Controller/Dashboard/AjaxDashboardControllerTest.php
@@ -8,7 +8,7 @@ use Goteo\Model\User;
 use Goteo\Controller\Dashboard\AjaxDashboardController;
 use Goteo\Application\Exception\ControllerAccessDeniedException;
 
-class AjaxDashboardControllerTest extends \PHPUnit_Framework_TestCase {
+class AjaxDashboardControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/Dashboard/ProjectDashboardControllerTest.php
+++ b/tests/Goteo/Controller/Dashboard/ProjectDashboardControllerTest.php
@@ -8,7 +8,7 @@ use Goteo\Model\User;
 use Goteo\Controller\Dashboard\ProjectDashboardController;
 use Goteo\Application\Exception\ControllerAccessDeniedException;
 
-class ProjectDashboardControllerTest extends \PHPUnit_Framework_TestCase {
+class ProjectDashboardControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/Dashboard/SettingsDashboardControllerTest.php
+++ b/tests/Goteo/Controller/Dashboard/SettingsDashboardControllerTest.php
@@ -8,7 +8,7 @@ use Goteo\Model\User;
 use Goteo\Controller\Dashboard\SettingsDashboardController;
 use Goteo\Application\Exception\ControllerAccessDeniedException;
 
-class SettingsDashboardControllerTest extends \PHPUnit_Framework_TestCase {
+class SettingsDashboardControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/Dashboard/TranslateProjectDashboardControllerTest.php
+++ b/tests/Goteo/Controller/Dashboard/TranslateProjectDashboardControllerTest.php
@@ -8,7 +8,7 @@ use Goteo\Model\User;
 use Goteo\Controller\Dashboard\TranslateProjectDashboardController;
 use Goteo\Application\Exception\ControllerAccessDeniedException;
 
-class TranslateProjectDashboardControllerTest extends \PHPUnit_Framework_TestCase {
+class TranslateProjectDashboardControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/DashboardControllerTest.php
+++ b/tests/Goteo/Controller/DashboardControllerTest.php
@@ -8,7 +8,7 @@ use Goteo\Model\User;
 use Goteo\Controller\DashboardController;
 use Goteo\Application\Exception\ControllerAccessDeniedException;
 
-class DashboardControllerTest extends \PHPUnit_Framework_TestCase {
+class DashboardControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/DiscoverControllerTest.php
+++ b/tests/Goteo/Controller/DiscoverControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\DiscoverController;
 
-class DiscoverControllerTest extends \PHPUnit_Framework_TestCase {
+class DiscoverControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/FaqTest.php
+++ b/tests/Goteo/Controller/FaqTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\Faq;
 
-class FaqTest extends \PHPUnit_Framework_TestCase {
+class FaqTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/GlossaryControllerTest.php
+++ b/tests/Goteo/Controller/GlossaryControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\GlossaryController;
 
-class GlossaryControllerTest extends \PHPUnit_Framework_TestCase {
+class GlossaryControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/ImageControllerTest.php
+++ b/tests/Goteo/Controller/ImageControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\ImageController;
 
-class ImageControllerTest extends \PHPUnit_Framework_TestCase {
+class ImageControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/IndexControllerTest.php
+++ b/tests/Goteo/Controller/IndexControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\IndexController;
 
-class IndexControllerTest extends \PHPUnit_Framework_TestCase {
+class IndexControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/InvestControllerTest.php
+++ b/tests/Goteo/Controller/InvestControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\InvestController;
 
-class InvestControllerTest extends \PHPUnit_Framework_TestCase {
+class InvestControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/MailControllerTest.php
+++ b/tests/Goteo/Controller/MailControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\MailController;
 
-class MailControllerTest extends \PHPUnit_Framework_TestCase {
+class MailControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/MessageTest.php
+++ b/tests/Goteo/Controller/MessageTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\Message;
 
-class MessageTest extends \PHPUnit_Framework_TestCase {
+class MessageTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/NewsTest.php
+++ b/tests/Goteo/Controller/NewsTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\News;
 
-class NewsTest extends \PHPUnit_Framework_TestCase {
+class NewsTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/NewsletterControllerTest.php
+++ b/tests/Goteo/Controller/NewsletterControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\NewsletterController;
 
-class NewsletterControllerTest extends \PHPUnit_Framework_TestCase {
+class NewsletterControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/ProjectControllerTest.php
+++ b/tests/Goteo/Controller/ProjectControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\ProjectController;
 
-class ProjectControllerTest extends \PHPUnit_Framework_TestCase {
+class ProjectControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/ReviewTest.php
+++ b/tests/Goteo/Controller/ReviewTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\Review;
 
-class ReviewTest extends \PHPUnit_Framework_TestCase {
+class ReviewTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/RssControllerTest.php
+++ b/tests/Goteo/Controller/RssControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\RssController;
 
-class RssControllerTest extends \PHPUnit_Framework_TestCase {
+class RssControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/TranslateControllerTest.php
+++ b/tests/Goteo/Controller/TranslateControllerTest.php
@@ -8,7 +8,7 @@ use Goteo\Model\User;
 use Goteo\Controller\TranslateController;
 use Goteo\Application\Exception\ControllerAccessDeniedException;
 
-class TranslateControllerTest extends \PHPUnit_Framework_TestCase {
+class TranslateControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/UserControllerTest.php
+++ b/tests/Goteo/Controller/UserControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\UserController;
 
-class UserControllerTest extends \PHPUnit_Framework_TestCase {
+class UserControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/WidgetControllerTest.php
+++ b/tests/Goteo/Controller/WidgetControllerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\WidgetController;
 
-class WidgetControllerTest extends \PHPUnit_Framework_TestCase {
+class WidgetControllerTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Controller/WsTest.php
+++ b/tests/Goteo/Controller/WsTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Controller\Tests;
 
 use Goteo\Controller\Ws;
 
-class WsTest extends \PHPUnit_Framework_TestCase {
+class WsTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Core/ACLTest.php
+++ b/tests/Goteo/Core/ACLTest.php
@@ -6,7 +6,7 @@ namespace Goteo\Core\Tests;
 use Goteo\Core\ACL;
 
 
-class ACLTest extends \PHPUnit_Framework_TestCase {
+class ACLTest extends \PHPUnit\Framework\TestCase {
     public function testInstance() {
 
         $test = new ACL();

--- a/tests/Goteo/Core/ControllerTest.php
+++ b/tests/Goteo/Core/ControllerTest.php
@@ -7,7 +7,7 @@ use Goteo\Core\Controller;
 class TestController extends Controller {
 }
 
-class ControllerTest extends \PHPUnit_Framework_TestCase {
+class ControllerTest extends \PHPUnit\Framework\TestCase {
     public function testInstance() {
 
         $test = new TestController();

--- a/tests/Goteo/Core/DBTest.php
+++ b/tests/Goteo/Core/DBTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Core\Tests;
 use Goteo\Core\DB,
     Goteo\Library\Cacher;
 
-class DBTest extends \PHPUnit_Framework_TestCase {
+class DBTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         DB::cache(false);

--- a/tests/Goteo/Core/ErrorTest.php
+++ b/tests/Goteo/Core/ErrorTest.php
@@ -4,7 +4,7 @@ namespace Goteo\Core\Tests;
 
 use Goteo\Core\Error;
 
-class ErrorTest extends \PHPUnit_Framework_TestCase {
+class ErrorTest extends \PHPUnit\Framework\TestCase {
     public function testInstance() {
         $err = new Error();
         $this->assertInstanceOf('\Goteo\Core\Error', $err);

--- a/tests/Goteo/Core/ExceptionTest.php
+++ b/tests/Goteo/Core/ExceptionTest.php
@@ -6,7 +6,7 @@ namespace Goteo\Core\Tests;
 class TestException extends \Goteo\Core\Exception {
 }
 
-class ExceptionTest extends \PHPUnit_Framework_TestCase {
+class ExceptionTest extends \PHPUnit\Framework\TestCase {
     public function testInstance() {
 
         $test = new TestException();

--- a/tests/Goteo/Core/ModelTest.php
+++ b/tests/Goteo/Core/ModelTest.php
@@ -2,12 +2,13 @@
 
 namespace Goteo\Core\Tests;
 
+use Exception;
 use Goteo\Core\Model;
 use Goteo\Core\ModelEvents;
 use Goteo\Core\DB;
-use Goteo\Library\Cacher;
 use Goteo\Application\Config;
 use Goteo\Application\App;
+use PDOException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Goteo\Core\Event\CreateModelEvent;
 use Goteo\Core\Event\UpdateModelEvent;
@@ -56,19 +57,20 @@ class MockModelListener implements EventSubscriberInterface {
         $model = $event->getModel();
         $model->name .= ' post-delete';
     }
-    public static function getSubscribedEvents() {
-        return array(
+    public static function getSubscribedEvents(): array
+    {
+        return [
             ModelEvents::CREATE => 'onCreate',
             ModelEvents::CREATED => 'onCreated',
             ModelEvents::UPDATE => 'onUpdate',
             ModelEvents::UPDATED => 'onUpdated',
             ModelEvents::DELETE => 'onDelete',
             ModelEvents::DELETED => 'onDeleted'
-        );
+        ];
     }
 }
 
-class ModelTest extends \PHPUnit_Framework_TestCase {
+class ModelTest extends \PHPUnit\Framework\TestCase {
     public static $listener;
 
     public static function setUpBeforeClass() {
@@ -76,7 +78,8 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
         self::$listener = new MockModelListener;
     }
 
-    public function testGetTable() {
+    public function testGetTable(): MockModel
+    {
         $mock = new MockModel();
         $this->assertEquals('mockmodel', $mock->getTable());
         return $mock;
@@ -118,7 +121,7 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
         try {
             $mock::query('STUPID QUERY');
         }
-        catch(\Exception $e) {
+        catch(Exception $e) {
             $this->assertInstanceOf('\PDOException', $e);
         }
         return $mock;
@@ -133,8 +136,8 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
                   `name` VARCHAR(100),
                   PRIMARY KEY (`id`),
                   UNIQUE INDEX (`uniq`) )";
-        // echo $sql;
-        $query = $mock::query($sql);
+        $mock::query($sql);
+        $this->assertTrue(true);
         return $mock;
     }
 
@@ -143,8 +146,8 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
      */
     public function testDbInsert($mock) {
         $tb = $mock->getTable();
-        $query = $mock::query("INSERT INTO $tb (uniq, name) VALUES ('test1', 'Name 1')");
-        $this->assertEquals($mock::dbCount(), 1);
+        $mock::query("INSERT INTO $tb (uniq, name) VALUES ('test1', 'Name 1')");
+        $this->assertEquals(1, $mock::dbCount());
         $query = $mock::query("SELECT * FROM $tb");
         $res = $query->fetchObject();
         $this->assertEquals('test1', $res->uniq);
@@ -152,11 +155,11 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
         try {
             $mock::query("INSERT INTO $tb (uniq, name) VALUES ('test1', 'Name 1')");
         }
-        catch(\Exception $e) {
+        catch(Exception $e) {
             $this->assertInstanceOf('\PDOException', $e);
         }
         $mock::query("TRUNCATE TABLE $tb");
-        $this->assertEquals($mock::dbCount(), 0);
+        $this->assertEquals(0, $mock::dbCount());
 
         $mock->uniq = 'test1';
         $mock->name = 'Name 2';
@@ -171,7 +174,7 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
         try {
             $mock->dbInsert(['uniq', 'name']);
         }
-        catch(\Exception $e) {
+        catch(Exception $e) {
             $this->assertInstanceOf('\PDOException', $e);
         }
         return $mock;
@@ -200,7 +203,7 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
         try {
             $mock->dbUpdate(['non-existing']);
         }
-        catch(\Exception $e) {
+        catch(Exception $e) {
             $this->assertInstanceOf('\PDOException', $e);
         }
         return $mock;
@@ -212,13 +215,13 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
     public function testDbInsertUpdate($mock) {
         $tb = $mock->getTable();
         $mock::query("TRUNCATE TABLE $tb");
-        $this->assertEquals($mock::dbCount(), 0);
+        $this->assertEquals(0, $mock::dbCount());
         $mock->id = null;
         $mock->uniq = 'test1';
         $mock->name = 'Name 1';
         try {
             $mock->dbUpdate(['uniq', 'name']);
-        } catch(\Exception $e) {
+        } catch(Exception $e) {
             $this->assertInstanceOf('\PDOException', $e);
         }
         $mock->dbInsertUpdate(['uniq', 'name']);
@@ -242,7 +245,7 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
             $mock->uniq = 'test2';
             $mock->dbInsertUpdate(['name']);
         }
-        catch(\Exception $e) {
+        catch(Exception $e) {
             $this->assertInstanceOf('\PDOException', $e);
         }
 
@@ -256,7 +259,7 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
         $this->assertNotEmpty($mock->dbDelete());
         try {
             $mock->dbDelete();
-        } catch(\Exception $e) {
+        } catch(Exception $e) {
             $this->assertInstanceOf('\PDOException', $e);
         }
         $this->assertEquals(0, $mock::dbCount());
@@ -358,13 +361,9 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
         $this->assertContains("IF('ca'='de', `mockmodel`.`title`, IFNULL(IFNULL(b.`title`,c.`title`), `mockmodel`.`title`)) AS `title`", $fields);
         $this->assertContains("LEFT JOIN `mockmodel_lang` b ON `mockmodel`.id=b.id AND b.lang='de' AND b.lang!='ca'", $joins);
 
-        // print_r($fields);
-        // print_r($joins);
         Config::set('sql_lang', $old_sql_lang);
         Config::set('lang', $old_lang);
-
     }
-
 
     /**
      */
@@ -387,7 +386,6 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
      * @depends testInsertEvents
      */
     public function testUpdateEvents($mock) {
-
         $mock->name = 'UPDATED';
         $this->assertNotEmpty($mock->dbUpdate(['name']));
         $this->assertEquals('UPDATED pre-update post-update', $mock->name);
@@ -407,7 +405,7 @@ class ModelTest extends \PHPUnit_Framework_TestCase {
             $mock->name = 'DELETED';
             $mock->dbDelete([]);
 
-        } catch(\PDOException $e) {
+        } catch(PDOException $e) {
             $this->assertEquals('DELETED pre-delete', $mock->name);
         }
         $mock->name = 'DELETED';

--- a/tests/Goteo/Core/NodeSysTest.php
+++ b/tests/Goteo/Core/NodeSysTest.php
@@ -6,7 +6,7 @@ namespace Goteo\Tests;
 use Goteo\Core\NodeSys;
 
 
-class NodeSysTest extends \PHPUnit_Framework_TestCase {
+class NodeSysTest extends \PHPUnit\Framework\TestCase {
     public function testInstance() {
 
         $test = new NodeSys();

--- a/tests/Goteo/Core/RedirectionTest.php
+++ b/tests/Goteo/Core/RedirectionTest.php
@@ -4,7 +4,7 @@ namespace Goteo\Core\Tests;
 
 use Goteo\Core\Redirection;
 
-class RedirectionTest extends \PHPUnit_Framework_TestCase {
+class RedirectionTest extends \PHPUnit\Framework\TestCase {
     public function testInstance() {
         $test = new Redirection('http://www.google.com');
         $this->assertInstanceOf('\Goteo\Core\Redirection', $test);

--- a/tests/Goteo/Core/ResourceTest.php
+++ b/tests/Goteo/Core/ResourceTest.php
@@ -13,7 +13,7 @@ class TestResourceMIME implements \Goteo\Core\Resource\MIME {
     }
 }
 
-class ResourceTest extends \PHPUnit_Framework_TestCase {
+class ResourceTest extends \PHPUnit\Framework\TestCase {
     public function testInstance() {
         $test = new TestResource();
         $this->assertInstanceOf('\Goteo\Core\Resource', $test);

--- a/tests/Goteo/Core/ViewTest.php
+++ b/tests/Goteo/Core/ViewTest.php
@@ -3,12 +3,7 @@
 namespace Goteo\Core\Tests;
 
 use Goteo\Core\View,
-    Goteo\Core\Redirection,
-    Goteo\Core\View\Exception,
-    Goteo\Application\Session,
-    Goteo\Model\Project,
-    Goteo\Model\Image,
-    Goteo\Model\User;
+    Goteo\Core\View\Exception;
 
 class ViewTest extends \Goteo\TestCase {
 
@@ -38,16 +33,10 @@ class ViewTest extends \Goteo\TestCase {
         $test = new Exception();
         $this->assertInstanceOf('\Goteo\Core\View\Exception', $test);
         try {
-            $test = new View('i-dont-exists.php');
-        }
-        catch(Exception $e) {
+            new View('i-dont-exists.php');
+        } catch(Exception $e) {
             $this->assertInstanceOf('\Goteo\Core\View\Exception', $e);
         }
-
-    }
-
-    public function testView() {
-
     }
 
     /**

--- a/tests/Goteo/Library/AmazonSnsTest.php
+++ b/tests/Goteo/Library/AmazonSnsTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\AmazonSns;
 
-class AmazonSnsTest extends \PHPUnit_Framework_TestCase {
+class AmazonSnsTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/BuzzTest.php
+++ b/tests/Goteo/Library/BuzzTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\Buzz;
 
-class BuzzTest extends \PHPUnit_Framework_TestCase {
+class BuzzTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/CheckTest.php
+++ b/tests/Goteo/Library/CheckTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\Check;
 
-class CheckTest extends \PHPUnit_Framework_TestCase {
+class CheckTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/ConverterTest.php
+++ b/tests/Goteo/Library/ConverterTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 use Goteo\Library\Converter;
 use Goteo\Library\ConverterReader;
 
-class ConverterTest extends \PHPUnit_Framework_TestCase {
+class ConverterTest extends \PHPUnit\Framework\TestCase {
     private $reader;
 
 	public function testInstance() {

--- a/tests/Goteo/Library/FeedTest.php
+++ b/tests/Goteo/Library/FeedTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\Feed;
 
-class FeedTest extends \PHPUnit_Framework_TestCase {
+class FeedTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/FileHandler/FileTest.php
+++ b/tests/Goteo/Library/FileHandler/FileTest.php
@@ -7,7 +7,7 @@ use Goteo\Library\FileHandler\File;
 use Goteo\Library\FileHandler\S3File;
 use Goteo\Library\FileHandler\LocalFile;
 
-class FileTest extends \PHPUnit_Framework_TestCase {
+class FileTest extends \PHPUnit\Framework\TestCase {
     protected static $handler = 'local';
     protected static $test_img ;
     protected static $path;

--- a/tests/Goteo/Library/ListingTest.php
+++ b/tests/Goteo/Library/ListingTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\Listing;
 
-class ListingTest extends \PHPUnit_Framework_TestCase {
+class ListingTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/NewsletterTest.php
+++ b/tests/Goteo/Library/NewsletterTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\Newsletter;
 
-class NewsletterTest extends \PHPUnit_Framework_TestCase {
+class NewsletterTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/NormalForm.php
+++ b/tests/Goteo/Library/NormalForm.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\NormalForm;
 
-class NormalFormTest extends \PHPUnit_Framework_TestCase {
+class NormalFormTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/Num2charTest.php
+++ b/tests/Goteo/Library/Num2charTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\Num2char;
 
-class Num2charTest extends \PHPUnit_Framework_TestCase {
+class Num2charTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/OAuth/SocialAuth.php
+++ b/tests/Goteo/Library/OAuth/SocialAuth.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\OAuth\SocialAuth;
 
-class SocialAuthTest extends \PHPUnit_Framework_TestCase {
+class SocialAuthTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/PayPalTest.php
+++ b/tests/Goteo/Library/PayPalTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use \PayPal\Service as PPService;
 
-class PayPalTest extends \PHPUnit_Framework_TestCase {
+class PayPalTest extends \PHPUnit\Framework\TestCase {
 
     // Aunque no es obligatorio que exista este archivo de configuración para compilar grunt
     // sí será obligatorio para que funcionen la pasarela de pago!

--- a/tests/Goteo/Library/ReportingTest.php
+++ b/tests/Goteo/Library/ReportingTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\Reporting;
 
-class ReportingTest extends \PHPUnit_Framework_TestCase {
+class ReportingTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/SearchTest.php
+++ b/tests/Goteo/Library/SearchTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\Search;
 
-class SearchTest extends \PHPUnit_Framework_TestCase {
+class SearchTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/SuperFormTest.php
+++ b/tests/Goteo/Library/SuperFormTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\SuperForm;
 
-class SuperFormTest extends \PHPUnit_Framework_TestCase {
+class SuperFormTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/WallFriendsTest.php
+++ b/tests/Goteo/Library/WallFriendsTest.php
@@ -6,7 +6,7 @@ namespace Goteo\Library\Tests;
 use Goteo\Library\WallFriends;
 use Goteo\Model\Project;
 
-class WallFriendsTest extends \PHPUnit_Framework_TestCase {
+class WallFriendsTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Library/WorthTest.php
+++ b/tests/Goteo/Library/WorthTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Library\Worth;
 
-class WorthTest extends \PHPUnit_Framework_TestCase {
+class WorthTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Blog/Post/CommentTest.php
+++ b/tests/Goteo/Model/Blog/Post/CommentTest.php
@@ -6,7 +6,7 @@ namespace Goteo\Model\Blog\Post\Tests;
 use Goteo\Model\Blog\Post\Comment;
 use Goteo\Model\Blog\Post;
 
-class CommentTest extends \PHPUnit_Framework_TestCase {
+class CommentTest extends \PHPUnit\Framework\TestCase {
     private static $data = array('text' => 'Test comment');
     private static $post_data = array('title' => 'Test post', 'text' => 'test text',
         'blog' => 1,

--- a/tests/Goteo/Model/Blog/Post/TagTest.php
+++ b/tests/Goteo/Model/Blog/Post/TagTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Blog\Post\Tests;
 
 use Goteo\Model\Blog\Post\Tag;
 
-class TagTest extends \PHPUnit_Framework_TestCase {
+class TagTest extends \PHPUnit\Framework\TestCase {
     private static $data = array('name' => 'Test category');
 
     public function testInstance() {

--- a/tests/Goteo/Model/Blog/PostTest.php
+++ b/tests/Goteo/Model/Blog/PostTest.php
@@ -6,7 +6,7 @@ namespace Goteo\Model\Blog\Tests;
 use Goteo\Model\Blog\Post;
 use Goteo\Model\Image;
 
-class PostTest extends \PHPUnit_Framework_TestCase {
+class PostTest extends \PHPUnit\Framework\TestCase {
     private static $data = array('title' => 'Test post', 'text' => 'test text',
         'blog' => 1,
         'date' => '2015-01-01',

--- a/tests/Goteo/Model/BlogTest.php
+++ b/tests/Goteo/Model/BlogTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Blog;
 
-class BlogTest extends \PHPUnit_Framework_TestCase {
+class BlogTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Call/BannerTest.php
+++ b/tests/Goteo/Model/Call/BannerTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Call\Tests;
 
 use Goteo\Model\Call\Banner;
 
-class BannerTest extends \PHPUnit_Framework_TestCase {
+class BannerTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('name' => 'test name', 'call' => 'test', 'order' => 0);
 

--- a/tests/Goteo/Model/Call/CategoryTest.php
+++ b/tests/Goteo/Model/Call/CategoryTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Call\Tests;
 
 use Goteo\Model\Call\Category;
 
-class CategoryTest extends \PHPUnit_Framework_TestCase {
+class CategoryTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Call/IconTest.php
+++ b/tests/Goteo/Model/Call/IconTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Call\Tests;
 
 use Goteo\Model\Call\Icon;
 
-class IconTest extends \PHPUnit_Framework_TestCase {
+class IconTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Call/PostTest.php
+++ b/tests/Goteo/Model/Call/PostTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Call\Tests;
 
 use Goteo\Model\Call\Post;
 
-class PostTest extends \PHPUnit_Framework_TestCase {
+class PostTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Call/ProjectTest.php
+++ b/tests/Goteo/Model/Call/ProjectTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Call\Tests;
 
 use Goteo\Model\Call\Project;
 
-class ProjectTest extends \PHPUnit_Framework_TestCase {
+class ProjectTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Call/SponsorTest.php
+++ b/tests/Goteo/Model/Call/SponsorTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Call\Tests;
 
 use Goteo\Model\Call\Sponsor;
 
-class SponsorTest extends \PHPUnit_Framework_TestCase {
+class SponsorTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('name' => 'test name', 'call' => 'test', 'order' => 0);
 

--- a/tests/Goteo/Model/CallTest.php
+++ b/tests/Goteo/Model/CallTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Call;
 
-class CallTest extends \PHPUnit_Framework_TestCase {
+class CallTest extends \PHPUnit\Framework\TestCase {
     private static $data = array('id' => 'test-project', 'owner' => 'test');
 
     public function testInstance() {

--- a/tests/Goteo/Model/CategoryTest.php
+++ b/tests/Goteo/Model/CategoryTest.php
@@ -8,7 +8,7 @@ use Goteo\Model\Sdg;
 use Goteo\Application\Config;
 use Goteo\Application\Lang;
 
-class CategoryTest extends \PHPUnit_Framework_TestCase {
+class CategoryTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = ['name' => 'Test category', 'description' => 'Test description'];
     private static $trans_data = ['name' => 'Categoria test', 'description' => 'Descripció test'];

--- a/tests/Goteo/Model/CriteriaTest.php
+++ b/tests/Goteo/Model/CriteriaTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Criteria;
 
-class CriteriaTest extends \PHPUnit_Framework_TestCase {
+class CriteriaTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('section' => 'test', 'title' => 'Test title', 'order' => 1);
 

--- a/tests/Goteo/Model/GlossaryTest.php
+++ b/tests/Goteo/Model/GlossaryTest.php
@@ -7,7 +7,7 @@ use Goteo\Model\Image;
 use Goteo\Application\Config;
 use Goteo\Application\Lang;
 
-class GlossaryTest extends \PHPUnit_Framework_TestCase {
+class GlossaryTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('title' => 'Test title', 'text' => 'Test text');
     private static $trans_data = array('title' => 'Test títle', 'text' => 'Test text traduït');

--- a/tests/Goteo/Model/IconTest.php
+++ b/tests/Goteo/Model/IconTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Icon;
 
-class IconTest extends \PHPUnit_Framework_TestCase {
+class IconTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('id' => 'test', 'name' => 'Test category', 'description' => 'Test description', 'order' => 0);
 

--- a/tests/Goteo/Model/ImageTest.php
+++ b/tests/Goteo/Model/ImageTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Image;
 
-class ImageTest extends \PHPUnit_Framework_TestCase {
+class ImageTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/InfoTest.php
+++ b/tests/Goteo/Model/InfoTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 use Goteo\Model\Info;
 use Goteo\Model\Image;
 
-class InfoTest extends \PHPUnit_Framework_TestCase {
+class InfoTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('title' => 'test title', 'text' => 'test description', 'publish' => 0);
 

--- a/tests/Goteo/Model/InvestTest.php
+++ b/tests/Goteo/Model/InvestTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Invest;
 
-class InvestTest extends \PHPUnit_Framework_TestCase {
+class InvestTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/LicenseTest.php
+++ b/tests/Goteo/Model/LicenseTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\License;
 
-class LicenseTest extends \PHPUnit_Framework_TestCase {
+class LicenseTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('id' => 'test', 'name' => 'Test category', 'description' => 'Test description');
 

--- a/tests/Goteo/Model/Location/LocationStatsTest.php
+++ b/tests/Goteo/Model/Location/LocationStatsTest.php
@@ -9,7 +9,7 @@ use Goteo\Model\Location\LocationStats;
 use Goteo\Model\User\UserLocation;
 use Goteo\Model\Project\ProjectLocation;
 
-class LocationStatsTest extends \PHPUnit_Framework_TestCase {
+class LocationStatsTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
         \Goteo\Core\DB::cache(false);

--- a/tests/Goteo/Model/Mail/MailStatsTest.php
+++ b/tests/Goteo/Model/Mail/MailStatsTest.php
@@ -7,7 +7,7 @@ use Goteo\Model\Mail\MailStats;
 use Goteo\Model\Template;
 use Goteo\Model\Mail;
 
-class MailStatsTest extends \PHPUnit_Framework_TestCase {
+class MailStatsTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Mail/MetricTest.php
+++ b/tests/Goteo/Model/Mail/MetricTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Mail\Tests;
 
 use Goteo\Model\Mail\Metric;
 
-class MetricTest extends \PHPUnit_Framework_TestCase {
+class MetricTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Mail/SenderRecipientTest.php
+++ b/tests/Goteo/Model/Mail/SenderRecipientTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Mail\Tests;
 
 use Goteo\Model\Mail\SenderRecipient;
 
-class SenderRecipientTest extends \PHPUnit_Framework_TestCase {
+class SenderRecipientTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Mail/SenderTest.php
+++ b/tests/Goteo/Model/Mail/SenderTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Mail\Tests;
 
 use Goteo\Model\Mail\Sender;
 
-class SenderTest extends \PHPUnit_Framework_TestCase {
+class SenderTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/MailTest.php
+++ b/tests/Goteo/Model/MailTest.php
@@ -5,6 +5,7 @@ namespace Goteo\Model\Tests;
 use Goteo\Model\Template;
 use Goteo\Model\Mail;
 use Goteo\Application\Config;
+use PHPMailer\PHPMailer\PHPMailer;
 
 class MailTest extends \PHPUnit_Framework_TestCase
 {
@@ -14,8 +15,8 @@ class MailTest extends \PHPUnit_Framework_TestCase
     public function testInstance(): Mail
     {
         $mail = new Mail();
-        $this->assertInstanceOf('\Goteo\Model\Mail', $mail);
-        $this->assertInstanceOf('\PHPMailer', $mail->mail);
+        $this->assertInstanceOf(Mail::class, $mail);
+        $this->assertInstanceOf(PHPMailer::class, $mail->mail);
         return $mail;
     }
 
@@ -43,7 +44,7 @@ class MailTest extends \PHPUnit_Framework_TestCase
     public function testMessage(Mail $mail)
     {
         $mailer = $mail->buildMessage();
-        $this->assertInstanceOf('\PHPMailer', $mailer);
+        $this->assertInstanceOf(PHPMailer::class, $mailer);
 
         $this->assertEquals('test@goteo.org', $mailer->getToAddresses()[0][0]);
 
@@ -89,7 +90,7 @@ class MailTest extends \PHPUnit_Framework_TestCase
     {
         $mail = Mail::createFromText('test@goteo.org', 'Test', 'Subject', "Body\nsecond line");
         $mailer = $mail->buildMessage();
-        $this->assertInstanceOf('\PHPMailer', $mailer);
+        $this->assertInstanceOf(PHPMailer::class, $mailer);
         $this->assertEquals('test@goteo.org', $mailer->getToAddresses()[0][0]);
         $this->assertEquals('Test', $mailer->getToAddresses()[0][1]);
         $this->assertContains('Subject', $mailer->Subject);
@@ -103,7 +104,7 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $mail = Mail::createFromHtml('test@goteo.org', 'Test', 'Subject', "Body<br>second line");
         $mailer = $mail->buildMessage();
 
-        $this->assertInstanceOf('\PHPMailer', $mailer);
+        $this->assertInstanceOf(PHPMailer::class, $mailer);
         $this->assertEquals('test@goteo.org', $mailer->getToAddresses()[0][0]);
         $this->assertEquals('Test', $mailer->getToAddresses()[0][1]);
         $this->assertContains('Subject', $mailer->Subject);
@@ -119,7 +120,7 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $mail = Mail::createFromTemplate('test@goteo.org', 'Test', Template::NEWSLETTER);
         $mailer = $mail->buildMessage();
 
-        $this->assertInstanceOf('\PHPMailer', $mailer);
+        $this->assertInstanceOf(PHPMailer::class, $mailer);
         $this->assertEquals('test@goteo.org', $mailer->getToAddresses()[0][0]);
         $this->assertEquals('Test', $mailer->getToAddresses()[0][1]);
         $this->assertContains($tpl->title, $mailer->Subject);

--- a/tests/Goteo/Model/MailTest.php
+++ b/tests/Goteo/Model/MailTest.php
@@ -7,7 +7,7 @@ use Goteo\Model\Mail;
 use Goteo\Application\Config;
 use PHPMailer\PHPMailer\PHPMailer;
 
-class MailTest extends \PHPUnit_Framework_TestCase
+class MailTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Ensures has the correct instances

--- a/tests/Goteo/Model/MessageTest.php
+++ b/tests/Goteo/Model/MessageTest.php
@@ -8,7 +8,7 @@ use Goteo\Model\User;
 use Goteo\Application\Config;
 use Goteo\Application\Lang;
 
-class MessageTest extends \PHPUnit_Framework_TestCase {
+class MessageTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('message' => 'Test message content');
     private static $trans_data = array('message' => 'Test contingut del missatge');

--- a/tests/Goteo/Model/NewsTest.php
+++ b/tests/Goteo/Model/NewsTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\News;
 
-class NewsTest extends \PHPUnit_Framework_TestCase {
+class NewsTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('title' => 'Test news', 'url' => 'http://goteo.org', 'order' => 1);
 

--- a/tests/Goteo/Model/Node/NodeProject.php
+++ b/tests/Goteo/Model/Node/NodeProject.php
@@ -6,7 +6,7 @@ namespace Goteo\Model\Node\Tests;
 use Goteo\Model\Node\NodeProject;
 use Goteo\Application\Exception\ModelNotFoundException;
 
-class NodeProjectTest extends \PHPUnit_Framework_TestCase {
+class NodeProjectTest extends \PHPUnit\Framework\TestCase {
 
   public function testInstance() {
 
@@ -16,7 +16,7 @@ class NodeProjectTest extends \PHPUnit_Framework_TestCase {
 
       return $ob;
   }
-    
+
   /**
    * @depends testInstance
    */

--- a/tests/Goteo/Model/OpenTagTest.php
+++ b/tests/Goteo/Model/OpenTagTest.php
@@ -7,7 +7,7 @@ use Goteo\Model\OpenTag;
 use Goteo\Application\Config;
 use Goteo\Application\Lang;
 
-class OpenTagTest extends \PHPUnit_Framework_TestCase {
+class OpenTagTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('name' => 'test name', 'description' => 'test description', 'order' => 0);
     private static $trans_data = array('name' => 'nom de test', 'description' => 'descripció test');

--- a/tests/Goteo/Model/PageTest.php
+++ b/tests/Goteo/Model/PageTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Library\Tests;
 
 use Goteo\Model\Page;
 
-class PageTest extends \PHPUnit_Framework_TestCase {
+class PageTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/PostTest.php
+++ b/tests/Goteo/Model/PostTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Post;
 
-class PostTest extends \PHPUnit_Framework_TestCase {
+class PostTest extends \PHPUnit\Framework\TestCase {
     private static $related_tables = array('post_node' => 'post',
                     'post_image' => 'post',
                     'post_lang' => 'id',

--- a/tests/Goteo/Model/Project/AccountTest.php
+++ b/tests/Goteo/Model/Project/AccountTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Project\Tests;
 
 use Goteo\Model\Project\Account;
 
-class AccountTest extends \PHPUnit_Framework_TestCase {
+class AccountTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Project/CategoryTest.php
+++ b/tests/Goteo/Model/Project/CategoryTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Project\Tests;
 
 use Goteo\Model\Project\Category;
 
-class CategoryTest extends \PHPUnit_Framework_TestCase {
+class CategoryTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Project/ConfTest.php
+++ b/tests/Goteo/Model/Project/ConfTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Project\Tests;
 
 use Goteo\Model\Project\Conf;
 
-class ConfTest extends \PHPUnit_Framework_TestCase {
+class ConfTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Project/CostTest.php
+++ b/tests/Goteo/Model/Project/CostTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Project\Tests;
 
 use Goteo\Model\Project\Cost;
 
-class CostTest extends \PHPUnit_Framework_TestCase {
+class CostTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Project/ImageTest.php
+++ b/tests/Goteo/Model/Project/ImageTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Project\Tests;
 
 use Goteo\Model\Project\Image;
 
-class ImageTest extends \PHPUnit_Framework_TestCase {
+class ImageTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Project/MediaTest.php
+++ b/tests/Goteo/Model/Project/MediaTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Project\Tests;
 
 use Goteo\Model\Project\Media;
 
-class MediaTest extends \PHPUnit_Framework_TestCase {
+class MediaTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Project/OpenTagTest.php
+++ b/tests/Goteo/Model/Project/OpenTagTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Project\Tests;
 
 use Goteo\Model\Project\OpenTag;
 
-class OpenTagTest extends \PHPUnit_Framework_TestCase {
+class OpenTagTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Project/ProjectLocationTest.php
+++ b/tests/Goteo/Model/Project/ProjectLocationTest.php
@@ -8,7 +8,7 @@ use Goteo\Model\Project\ProjectLocation;
 use Goteo\Model\User;
 use Goteo\Model\User\UserLocation;
 
-class ProjectLocationTest extends \PHPUnit_Framework_TestCase {
+class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
     private static $data = array(
             'city' => 'Simulated City',
             'region' => 'Simulated Region',

--- a/tests/Goteo/Model/Project/RewardTest.php
+++ b/tests/Goteo/Model/Project/RewardTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Project\Tests;
 
 use Goteo\Model\Project\Reward;
 
-class RewardTest extends \PHPUnit_Framework_TestCase {
+class RewardTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/Project/SupportTest.php
+++ b/tests/Goteo/Model/Project/SupportTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Project\Tests;
 
 use Goteo\Model\Project\Support;
 
-class SupportTest extends \PHPUnit_Framework_TestCase {
+class SupportTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/ProjectTest.php
+++ b/tests/Goteo/Model/ProjectTest.php
@@ -3,6 +3,8 @@
 
 namespace Goteo\Model\Tests;
 
+use Exception;
+use Goteo\Application\Exception\ModelNotFoundException;
 use Goteo\TestCase;
 
 use Goteo\Application\Config;
@@ -104,7 +106,6 @@ class ProjectTest extends TestCase {
         $this->assertFalse($ob->save());
     }
 
-
     public function testCreateUser() {
         delete_test_user();
         delete_test_node();
@@ -114,7 +115,7 @@ class ProjectTest extends TestCase {
             $project = Project::get(self::$data['id']);
             $project->remove();
         } catch(\Exception $e) {
-            // project not exists, ok
+            $this->assertInstanceOf(ModelNotFoundException::class, $e);
         }
     }
 
@@ -312,12 +313,12 @@ class ProjectTest extends TestCase {
     public function testNonExisting() {
         try {
             $ob = Project::get(self::$data['id']);
-        }catch(\Exception $e) {
+        }catch(Exception $e) {
             $this->assertInstanceOf('\Goteo\Application\Exception\ModelNotFoundException', $e);
         }
         try {
             $ob = Project::get('non-existing-project');
-        }catch(\Exception $e) {
+        }catch(Exception $e) {
             $this->assertInstanceOf('\Goteo\Application\Exception\ModelNotFoundException', $e);
         }
     }

--- a/tests/Goteo/Model/ReviewTest.php
+++ b/tests/Goteo/Model/ReviewTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Review;
 
-class ReviewTest extends \PHPUnit_Framework_TestCase {
+class ReviewTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/StoriesTest.php
+++ b/tests/Goteo/Model/StoriesTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Stories;
 
-class StoriesTest extends \PHPUnit_Framework_TestCase {
+class StoriesTest extends \PHPUnit\Framework\TestCase {
 
     private static $data = array('title' => 'story title', 'description' => 'Test description', 'order' => 1, 'active' => 0);
 

--- a/tests/Goteo/Model/TemplateTest.php
+++ b/tests/Goteo/Model/TemplateTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\Tests;
 
 use Goteo\Model\Template;
 
-class TemplateTest extends \PHPUnit_Framework_TestCase {
+class TemplateTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/User/ApikeyTest.php
+++ b/tests/Goteo/Model/User/ApikeyTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\User\Tests;
 
 use Goteo\Model\User\Apikey;
 
-class ApikeyTest extends \PHPUnit_Framework_TestCase {
+class ApikeyTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/User/InterestTest.php
+++ b/tests/Goteo/Model/User/InterestTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\User\Tests;
 
 use Goteo\Model\User\Interest;
 
-class InterestTest extends \PHPUnit_Framework_TestCase {
+class InterestTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/User/ReviewTest.php
+++ b/tests/Goteo/Model/User/ReviewTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\User\Tests;
 
 use Goteo\Model\User\Review;
 
-class ReviewTest extends \PHPUnit_Framework_TestCase {
+class ReviewTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/User/TranslateTest.php
+++ b/tests/Goteo/Model/User/TranslateTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\User\Tests;
 
 use Goteo\Model\User\Translate;
 
-class TranslateTest extends \PHPUnit_Framework_TestCase {
+class TranslateTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/User/UserLocationTest.php
+++ b/tests/Goteo/Model/User/UserLocationTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\User\Tests;
 use Goteo\Model\User;
 use Goteo\Model\User\UserLocation;
 
-class UserLocationTest extends \PHPUnit_Framework_TestCase {
+class UserLocationTest extends \PHPUnit\Framework\TestCase {
     private static $data = array(
             'city' => 'Simulated City',
             'region' => 'Simulated Region',

--- a/tests/Goteo/Model/User/UserRolesTest.php
+++ b/tests/Goteo/Model/User/UserRolesTest.php
@@ -6,7 +6,7 @@ namespace Goteo\Model\User\Tests;
 use Goteo\Model\User;
 use Goteo\Model\User\UserRoles;
 
-class UserRolesTest extends \PHPUnit_Framework_TestCase {
+class UserRolesTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/User/VipTest.php
+++ b/tests/Goteo/Model/User/VipTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\User\Tests;
 
 use Goteo\Model\User\Vip;
 
-class VipTest extends \PHPUnit_Framework_TestCase {
+class VipTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Model/User/WebTest.php
+++ b/tests/Goteo/Model/User/WebTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Model\User\Tests;
 
 use Goteo\Model\User\Web;
 
-class WebTest extends \PHPUnit_Framework_TestCase {
+class WebTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Payment/Method/CashPaymentMethod.php
+++ b/tests/Goteo/Payment/Method/CashPaymentMethod.php
@@ -5,7 +5,7 @@ namespace Goteo\Payment\Tests;
 use Goteo\Payment\Method;
 use Goteo\Application\Config;
 
-class CashPaymentMethodTest extends \PHPUnit_Framework_TestCase {
+class CashPaymentMethodTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Payment/Method/PaypalPaymentMethod.php
+++ b/tests/Goteo/Payment/Method/PaypalPaymentMethod.php
@@ -4,7 +4,7 @@ namespace Goteo\Payment\Tests;
 
 use Goteo\Payment\Method;
 
-class PaypalPaymentMethodTest extends \PHPUnit_Framework_TestCase {
+class PaypalPaymentMethodTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Payment/Method/PoolPaymentMethod.php
+++ b/tests/Goteo/Payment/Method/PoolPaymentMethod.php
@@ -4,7 +4,7 @@ namespace Goteo\Payment\Tests;
 
 use Goteo\Payment\Method;
 
-class PoolPaymentMethodTest extends \PHPUnit_Framework_TestCase {
+class PoolPaymentMethodTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Payment/PaymentTest.php
+++ b/tests/Goteo/Payment/PaymentTest.php
@@ -9,7 +9,7 @@ class MockPaymentMethod extends AbstractPaymentMethod {
 
 }
 
-class PaymentTest extends \PHPUnit_Framework_TestCase {
+class PaymentTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 
@@ -42,7 +42,7 @@ class PaymentTest extends \PHPUnit_Framework_TestCase {
         $this->assertContainsOnlyInstancesOf('Goteo\Payment\Method\PaymentMethodInterface', $methods);
         return $methods;
     }
-   
+
     public function testGetMethod() {
         $this->assertInstanceOf('Goteo\Payment\Method\PaymentMethodInterface', Payment::getMethod('mock'));
     }

--- a/tests/Goteo/Util/Google/GoogleGeocoder.php
+++ b/tests/Goteo/Util/Google/GoogleGeocoder.php
@@ -4,7 +4,7 @@ namespace Goteo\Util\Tests;
 
 use Goteo\Util\Google\GoogleGeocoder;
 
-class GoogleGeocoderTest extends \PHPUnit_Framework_TestCase {
+class GoogleGeocoderTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Util/Origins/ParserTest.php
+++ b/tests/Goteo/Util/Origins/ParserTest.php
@@ -5,7 +5,7 @@ namespace Goteo\Util\Tests;
 use Goteo\Util\Origins\Parser;
 use Symfony\Component\HttpFoundation\Request;
 
-class ParserTest extends \PHPUnit_Framework_TestCase {
+class ParserTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Util/Pagination/DoubleBarLayoutTest.php
+++ b/tests/Goteo/Util/Pagination/DoubleBarLayoutTest.php
@@ -4,7 +4,7 @@ namespace Goteo\Util\Tests;
 
 use Goteo\Util\Pagination\DoubleBarLayout;
 
-class DoubleBarLayoutTest extends \PHPUnit_Framework_TestCase {
+class DoubleBarLayoutTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
 

--- a/tests/Goteo/Util/Pagination/PaginatedTest.php
+++ b/tests/Goteo/Util/Pagination/PaginatedTest.php
@@ -4,7 +4,7 @@ namespace Goteo\Util\Tests;
 
 use Goteo\Util\Pagination\Paginated;
 
-class PaginatedTest extends \PHPUnit_Framework_TestCase {
+class PaginatedTest extends \PHPUnit\Framework\TestCase {
 
     protected $page;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,7 +85,6 @@ function delete_test_node() {
 
     try {
         \Goteo\Model\Node::get('testnode');
-        error_log('unknow error deleting test node! ' . print_r($errors, 1));
     }
     catch(\Goteo\Application\Exception\ModelNotFoundException $e) {
         return true;
@@ -143,7 +142,7 @@ function get_test_project() {
         return \Goteo\Model\Project::get($data['id']);
     }
     catch(\Goteo\Application\Exception\ModelNotFoundException $e) {
-        error_log('Project [' . $data['id'] . '] not found, creating...');
+//        error_log('Project [' . $data['id'] . '] not found, creating...');
     }
     catch(\PDOException $e) {
         error_log('PDOException on deleting test project! ' . $e->getMessage());
@@ -180,7 +179,7 @@ function delete_test_project() {
         $project->dbDelete();
     }
     catch(\Goteo\Application\Exception\ModelNotFoundException $e) {
-        error_log('Already deleted test project');
+//        error_log('Already deleted test project');
     }
 
     try {


### PR DESCRIPTION
Updated the following dependencies:
- PHPUnit (to 6.5) => This implied changing the namespace for the PHPUnit tests
- PHPMailer (to latest version)
- Mockery (to latest compatible version, needs updating PHP for a more recent version)
- tpyo/amazon-s3-php-class (with latest commit and fix version to it)
- Added required PHP extensions: pdo and openssl

Reduced verbosity while executing all tests, so we can focus on seeing the result of the tests and not specific errors.

More info: https://docs.google.com/document/d/1cfJqQ1Wl_15r8iQFrRNKNmdI8zPJcQrN98oi8Kzafrc/edit?usp=sharing