### PR TITLE
Feature/upgrade phpunit to 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "ext-pdo": "*",
         "ext-openssl": "*",
         "foil/foil": "~0.6",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^7.0",
         "guzzle/plugin-mock": "~3.1"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "tests/bootstrap.php">
 
     <testsuites>

--- a/src/Goteo/Model/Glossary.php
+++ b/src/Goteo/Model/Glossary.php
@@ -35,8 +35,8 @@ class Glossary extends \Goteo\Core\Model {
     /*
      *  Devuelve datos de una entrada
      */
-    public static function get ($id, $lang = null) {
-
+    public static function get ($id, $lang = null):Glossary
+    {
         if(!$lang) $lang = Lang::current();
         list($fields, $joins) = self::getLangsSQLJoins($lang, Config::get('sql_lang'));
 

--- a/tests/Goteo/Application/ConfigTest.php
+++ b/tests/Goteo/Application/ConfigTest.php
@@ -10,8 +10,8 @@ use Symfony\Component\Yaml\Exception\ParseException;
 
 class ConfigTest extends \PHPUnit\Framework\TestCase {
 
-    public function testInstance() {
-
+    public function testInstance(): Config
+    {
         $ob = new Config();
 
         $this->assertInstanceOf('\Goteo\Application\Config', $ob);
@@ -19,17 +19,14 @@ class ConfigTest extends \PHPUnit\Framework\TestCase {
         return $ob;
     }
 
-    /**
-     * Validate YAML lang files
-     */
-    public function testYamlLangFiles() {
+    public function testValidateYamlLangFiles() {
         try {
             foreach (Lang::listAll('name', false) as $lang => $name) {
                 foreach (Config::$trans_groups as $group) {
                     $file = GOTEO_PATH . 'Resources/translations/' . $lang . '/' . $group . '.yml';
                     if(is_file($file)) {
                         $yaml = Yaml::parse(file_get_contents($file));
-                        if($yaml) $this->assertInternalType('array', $yaml, $file);
+                        if($yaml) $this->assertIsArray($yaml, $file);
                     }
                 }
             }

--- a/tests/Goteo/Application/LangTest.php
+++ b/tests/Goteo/Application/LangTest.php
@@ -7,8 +7,8 @@ use Goteo\Application\Lang;
 
 class LangTest extends \PHPUnit\Framework\TestCase {
 
-    public function testInstance() {
-
+    public function testInstance(): Lang
+    {
         $ob = new Lang();
 
         $this->assertInstanceOf('\Goteo\Application\Lang', $ob);
@@ -16,16 +16,16 @@ class LangTest extends \PHPUnit\Framework\TestCase {
         return $ob;
     }
 
-    public function testList() {
-        $this->assertInternalType('array', Lang::listAll());
+    public function testList(): array
+    {
+        $this->assertIsArray(Lang::listAll());
         $all = Lang::listAll('array', false);
-        $this->assertInternalType('array', $all);
+        $this->assertIsArray($all);
         return $all;
     }
 
     /**
      * @depends testList
-     * @return [type] [description]
      */
     public function testShortFunctions($all) {
         Lang::setDefault('es');
@@ -49,23 +49,22 @@ class LangTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @depends testList
-     * @return [type] [description]
      */
-    public function testSetters($all) {
-        foreach(Lang::listAll('short') as $lang => $info) {
-            $this->assertInternalType('string', $info);
+    public function testSetters() {
+        foreach(Lang::listAll('short') as $info) {
+            $this->assertIsString($info);
         }
-        foreach(Lang::listAll('locale') as $lang => $info) {
-            $this->assertInternalType('string', $info);
+        foreach(Lang::listAll('locale') as $info) {
+            $this->assertIsString($info);
         }
-        foreach(Lang::listAll('name') as $lang => $info) {
-            $this->assertInternalType('string', $info);
+        foreach(Lang::listAll('name') as $info) {
+            $this->assertIsString($info);
         }
-        foreach(Lang::listAll('object') as $lang => $info) {
-            $this->assertInternalType('object', $info);
+        foreach(Lang::listAll('object') as $info) {
+            $this->assertIsObject($info);
         }
         foreach(Lang::listAll('array') as $lang => $info) {
-            $this->assertInternalType('array', $info);
+            $this->assertIsArray($info);
             Lang::set($lang);
             $this->assertEquals($lang, Lang::current());
             $this->assertTrue(Lang::isActive($lang, false));

--- a/tests/Goteo/Application/RoleTest.php
+++ b/tests/Goteo/Application/RoleTest.php
@@ -14,7 +14,7 @@ class RoleTest extends \PHPUnit\Framework\TestCase {
 
 	}
 	public function testDefaults() {
-		$this->assertInternalType('array', Role::getRolePerms('non-existing-role'));
+		$this->assertIsArray(Role::getRolePerms('non-existing-role'));
 		try {
 			Role::addRolePerms('non-existing-role', 'test');
 		} catch (\Exception $e) {
@@ -35,12 +35,12 @@ class RoleTest extends \PHPUnit\Framework\TestCase {
 		Role::addRolesFromArray($roles);
 		$roles = Role::getRoles();
 
-		$this->assertInternalType('array', $roles);
+		$this->assertIsArray($roles);
 		$this->assertArrayHasKey('user1', $roles);
 		$this->assertArrayHasKey('admin1', $roles);
 
-		$this->assertInternalType('array', $roles['user1']);
-		$this->assertInternalType('array', $roles['admin1']);
+		$this->assertIsArray($roles['user1']);
+		$this->assertIsArray($roles['admin1']);
 
 		$this->assertContains('perm1', $roles['user1']);
 		$this->assertContains('perm2', $roles['user1']);
@@ -49,11 +49,9 @@ class RoleTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testExtendedRoles() {
-
 		$roles = Role::getRoles();
 		$this->assertContains('perm1', $roles['admin1']);
 		$this->assertContains('perm2', $roles['admin1']);
-
 	}
 
 	public function testRoleExists() {
@@ -95,7 +93,7 @@ class RoleTest extends \PHPUnit\Framework\TestCase {
 
         $permissions = Role::getPerms();
 
-        $this->assertInternalType('array', $permissions);
+        $this->assertIsArray($permissions);
         $this->assertArrayHasKey('perm-test1', $permissions);
         $this->assertArrayHasKey('perm-test2', $permissions);
         $this->assertContains('user_testmodel', $permissions['perm-test2']['relational'], print_r($permissions['perm-test2'], 1));

--- a/tests/Goteo/Core/ViewTest.php
+++ b/tests/Goteo/Core/ViewTest.php
@@ -64,7 +64,7 @@ class ViewTest extends \Goteo\TestCase {
                 $v = new View($view, $vars);
                 $this->assertInstanceOf('\Goteo\Core\View', $v);
                 $out = $v->render();
-                $this->assertInternalType('string', $out);
+                $this->assertIsString($out);
             }
             catch(\Goteo\Application\Exception\ModelNotFoundException $e) {
                 echo "\nLa vista [$view] lanza una exception de modelo!\nEsto no deberia hacerse aqui!\n";

--- a/tests/Goteo/Model/BannerTest.php
+++ b/tests/Goteo/Model/BannerTest.php
@@ -81,7 +81,7 @@ class BannerTest extends TestCase {
      */
     public function testListing($ob) {
         $list = Banner::getAll(false, get_test_node()->id);
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $new = $list[$ob->id];
         $this->assertInstanceOf('Goteo\Model\Banner', $new);
         $this->assertEquals(self::$data['title'], $new->title);
@@ -89,7 +89,7 @@ class BannerTest extends TestCase {
 
         Lang::set('ca');
         $list = Banner::getAll(false, get_test_node()->id);
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $new2 = $list[$ob->id];
         $this->assertEquals(self::$trans_data['title'], $new2->title);
         $this->assertEquals(self::$trans_data['description'], $new2->description);

--- a/tests/Goteo/Model/Blog/PostTest.php
+++ b/tests/Goteo/Model/Blog/PostTest.php
@@ -3,6 +3,7 @@
 
 namespace Goteo\Model\Blog\Tests;
 
+use Goteo\Core\DB;
 use Goteo\Model\Blog\Post;
 use Goteo\Model\Image;
 
@@ -41,8 +42,9 @@ class PostTest extends \PHPUnit\Framework\TestCase {
         self::$image2['size'] = strlen($i);
     }
 
-    public function testInstance() {
-        \Goteo\Core\DB::cache(false);
+    public function testInstance(): Post
+    {
+        DB::cache(false);
 
         $ob = new Post();
 
@@ -53,7 +55,7 @@ class PostTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testInstance
      */
-    public function testValidatePost($ob) {
+    public function testValidatePost(Post $ob) {
         $this->assertFalse($ob->validate());
         $this->assertFalse($ob->save());
     }
@@ -61,19 +63,19 @@ class PostTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testInstance
      */
-    public function testCreatePost() {
+    public function testCreatePost(): Post
+    {
         $ob = new Post(self::$data);
         $this->assertTrue($ob->validate($errors));
         $this->assertTrue($ob->save());
 
         return $ob;
-
     }
 
     /**
      * @depends testCreatePost
      */
-    public function testGetPost($ob) {
+    public function testGetPost(Post $ob) {
         $ob = Post::getById($ob->id);
         $this->assertInstanceOf('\Goteo\Model\Blog\Post', $ob);
 
@@ -87,7 +89,7 @@ class PostTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testGetPost
      */
-    public function testSlugPost($ob) {
+    public function testSlugPost(Post $ob) {
         $this->assertEquals('test-post', $ob->getSlug());
         $this->assertEquals($ob->id, Post::getBySlug($ob->getSlug())->id);
         $this->assertEquals($ob->id, Post::getById($ob->id)->id);
@@ -102,10 +104,11 @@ class PostTest extends \PHPUnit\Framework\TestCase {
 
         return $ob;
     }
+
     /**
      * @depends testGetPost
      */
-    public function testEditPost($ob) {
+    public function testEditPost(Post $ob) {
         //add image
         $ob->title = self::$data['title'] . " (edited)";
 
@@ -120,25 +123,24 @@ class PostTest extends \PHPUnit\Framework\TestCase {
 
         $sob = Post::getById($ob->id);
         $this->assertEquals($sob->title, $ob->title);
-        $this->assertInternalType('array', $ob->gallery);
-        $this->assertInternalType('array', $sob->gallery);
+        $this->assertIsArray($ob->gallery);
+        $this->assertIsArray($sob->gallery);
         $this->assertCount(2, $sob->gallery);
         $this->assertEquals($sob->gallery[0]->id, $ob->gallery[0]->id);
-        // $this->assertEquals($sob->image->id, $ob->gallery[1]->id, print_r($ob->gallery));
 
         return $sob;
     }
+
     /**
      * @depends testEditPost
      */
-    public function testRemoveImagePost($ob) {
+    public function testRemoveImagePost(Post $ob) {
         $errors = array();
 
-        // $this->assertEquals($ob->image->id, Image::getModelImage('', $ob->gallery)->id);
         $this->assertTrue($ob->image->remove($errors, 'post'), print_r($errors, 1));
         $ob->gallery = Image::getModelGallery('post', $ob->id);
         $ob->image = Image::getModelImage('', $ob->gallery);
-        $this->assertInternalType('array', $ob->gallery);
+        $this->assertIsArray($ob->gallery);
         $this->assertCount(1, $ob->gallery);
         $this->assertEquals($ob->image->id, $ob->gallery[0]->id);
 
@@ -146,7 +148,7 @@ class PostTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($ob->image, Image::getModelImage('', $ob->gallery));
         $this->assertTrue($ob->gallery[0]->remove($errors, 'post'), print_r($errors, 1));
         $ob = Post::getById($ob->id);
-        $this->assertInternalType('array', $ob->gallery);
+        $this->assertIsArray($ob->gallery);
         $this->assertCount(0, $ob->gallery);
         $this->assertEmpty($ob->image);
 
@@ -156,15 +158,16 @@ class PostTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue($ob->validate($errors));
         $this->assertTrue($ob->save());
         $ob = Post::getById($ob->id);
-        $this->assertInternalType('array', $ob->gallery);
+        $this->assertIsArray($ob->gallery);
         $this->assertCount(1, $ob->gallery);
         $this->assertEquals($ob->image, $ob->gallery[0]);
         return $ob;
     }
+
     /**
      * @depends testRemoveImagePost
      */
-    public function testDeletePost($ob) {
+    public function testDeletePost(Post $ob) {
         //delete post
         $this->assertTrue($ob->dbDelete());
 
@@ -174,7 +177,7 @@ class PostTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testDeletePost
      */
-    public function testNonExisting($ob) {
+    public function testNonExisting(Post $ob) {
         $sob = Post::getById($ob->id);
         $this->assertFalse($sob);
     }
@@ -184,11 +187,8 @@ class PostTest extends \PHPUnit\Framework\TestCase {
             $this->assertEquals(0, Post::query("SELECT COUNT(*) FROM $tb WHERE $field NOT IN (SELECT id FROM post)")->fetchColumn(), "DB incoherences in table [$tb], Please run SQL command:\nDELETE FROM $tb WHERE $field NOT IN (SELECT id FROM post)");
         }
     }
-    /**
-     * Some cleanup
-     */
+
     static function tearDownAfterClass() {
-        // Remove temporal files on finish
         unlink(self::$image['tmp_name']);
         unlink(self::$image2['tmp_name']);
     }

--- a/tests/Goteo/Model/FaqTest.php
+++ b/tests/Goteo/Model/FaqTest.php
@@ -19,7 +19,8 @@ class FaqTest extends TestCase {
         Lang::set('es');
     }
 
-    public function testInstance() {
+    public function testInstance(): Faq
+    {
         \Goteo\Core\DB::cache(false);
 
         $ob = new Faq();
@@ -32,7 +33,7 @@ class FaqTest extends TestCase {
     /**
      * @depends testInstance
      */
-    public function testValidate($ob) {
+    public function testValidate(Faq $ob) {
         $this->assertFalse($ob->validate());
         $this->assertFalse($ob->save());
     }
@@ -54,7 +55,7 @@ class FaqTest extends TestCase {
     /**
      * @depends testCreate
      */
-    public function testSaveLanguages($ob) {
+    public function testSaveLanguages(Faq $ob) {
         $errors = [];
         $this->assertTrue($ob->setLang('ca', self::$trans_data, $errors), print_r($errors, 1));
         return $ob;
@@ -63,7 +64,7 @@ class FaqTest extends TestCase {
     /**
      * @depends testSaveLanguages
      */
-    public function testCheckLanguages($ob) {
+    public function testCheckLanguages(Faq $ob) {
         $faq = Faq::get($ob->id);
         $this->assertInstanceOf('Goteo\Model\Faq', $faq);
         $this->assertEquals(self::$data['title'], $faq->title);
@@ -79,9 +80,9 @@ class FaqTest extends TestCase {
     /**
      * @depends testCreate
      */
-    public function testListing($ob) {
+    public function testListing() {
         $list = Faq::getAll('test-section');
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $faq = end($list);
         $this->assertInstanceOf('Goteo\Model\Faq', $faq);
         $this->assertEquals(self::$data['title'], $faq->title);
@@ -89,7 +90,7 @@ class FaqTest extends TestCase {
 
         Lang::set('ca');
         $list = Faq::getAll('test-section');
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $faq2 = end($list);
         $this->assertEquals(self::$trans_data['title'], $faq2->title);
         $this->assertEquals(self::$trans_data['description'], $faq2->description);
@@ -100,7 +101,8 @@ class FaqTest extends TestCase {
     /**
      * @depends testCreate
      */
-    public function testDelete($ob) {
+    public function testDelete(Faq $ob): Faq
+    {
         $this->assertTrue($ob->dbDelete());
 
         //save and delete statically
@@ -115,7 +117,7 @@ class FaqTest extends TestCase {
     /**
      * @depends testDelete
      */
-    public function testNonExisting($ob) {
+    public function testNonExisting(Faq $ob) {
         $ob = Faq::get($ob->id);
         $this->assertFalse($ob);
         $this->assertFalse(Faq::remove($ob->id));

--- a/tests/Goteo/Model/GlossaryTest.php
+++ b/tests/Goteo/Model/GlossaryTest.php
@@ -2,6 +2,7 @@
 
 namespace Goteo\Model\Tests;
 
+use Goteo\Core\DB;
 use Goteo\Model\Glossary;
 use Goteo\Model\Image;
 use Goteo\Application\Config;
@@ -42,8 +43,9 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
         self::$image2['size'] = strlen($i);
     }
 
-    public function testInstance() {
-        \Goteo\Core\DB::cache(false);
+    public function testInstance(): Glossary
+    {
+        DB::cache(false);
 
         $ob = new Glossary();
 
@@ -55,7 +57,7 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testInstance
      */
-    public function testValidate($ob) {
+    public function testValidate(Glossary $ob) {
         $this->assertFalse($ob->validate());
         $this->assertFalse($ob->save());
     }
@@ -63,19 +65,20 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
      /**
      * @depends testInstance
      */
-    public function testCreateGlossary() {
+    public function testCreateGlossary(): Glossary
+    {
         $ob = new Glossary(self::$data);
         $this->assertTrue($ob->validate($errors));
-        $this->assertTrue($ob->save($errors), $errors);
+        $this->assertTrue($ob->save($errors));
         $this->assertNotEmpty($ob->id);
         return $ob;
-
     }
 
     /**
      * @depends testCreateGlossary
      */
-    public function testGetGlossary($ob) {
+    public function testGetGlossary(Glossary $ob): Glossary
+    {
         $ob = Glossary::get($ob->id);
         $this->assertInstanceOf('\Goteo\Model\Glossary', $ob);
 
@@ -89,7 +92,8 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testGetGlossary
      */
-    public function testEditGlossary($ob) {
+    public function testEditGlossary(Glossary $ob): Glossary
+    {
         $ob->title = self::$data['title'] . " (edited)";
 
         //add image
@@ -104,22 +108,23 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
 
         $sob = Glossary::get($ob->id);
         $this->assertEquals($sob->title, $ob->title);
-        $this->assertInternalType('array', $ob->gallery);
-        $this->assertInternalType('array', $sob->gallery);
+        $this->assertIsArray($ob->gallery);
+        $this->assertIsArray($sob->gallery);
         $this->assertCount(2, $sob->gallery);
         $this->assertEquals($sob->gallery[0]->id, $ob->gallery[0]->id);
         $this->assertEquals($sob->image->id, $ob->gallery[0]->id);
         return $sob;
     }
+
     /**
      * @depends testEditGlossary
      */
-    public function testRemoveImageGlossary($ob) {
+    public function testRemoveImageGlossary(Glossary $ob) {
         $errors = array();
         $this->assertEquals($ob->image, Image::getModelImage('', $ob->gallery));
         $this->assertTrue($ob->gallery[0]->remove($errors, 'glossary'), print_r($errors, 1));
         $ob = Glossary::get($ob->id);
-        $this->assertInternalType('array', $ob->gallery);
+        $this->assertIsArray($ob->gallery);
         $this->assertCount(1, $ob->gallery);
         $this->assertEquals($ob->image, $ob->gallery[0]);
 
@@ -127,7 +132,7 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($ob->image, Image::getModelImage('', $ob->gallery));
         $this->assertTrue($ob->gallery[0]->remove($errors, 'glossary'), print_r($errors, 1));
         $ob = Glossary::get($ob->id);
-        $this->assertInternalType('array', $ob->gallery);
+        $this->assertIsArray($ob->gallery);
         $this->assertCount(0, $ob->gallery);
         $this->assertEmpty($ob->image);
 
@@ -137,16 +142,16 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue($ob->validate($errors));
         $this->assertTrue($ob->save());
         $ob = Glossary::get($ob->id);
-        $this->assertInternalType('array', $ob->gallery);
+        $this->assertIsArray($ob->gallery);
         $this->assertCount(1, $ob->gallery);
         $this->assertEquals($ob->image, $ob->gallery[0]);
-
     }
 
     /**
      * @depends testGetGlossary
      */
-    public function testSaveLanguages($ob) {
+    public function testSaveLanguages(Glossary $ob): Glossary
+    {
         $errors = [];
         $this->assertTrue($ob->setLang('ca', self::$trans_data, $errors), print_r($errors, 1));
         return $ob;
@@ -155,10 +160,9 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testSaveLanguages
      */
-    public function testCheckLanguages($ob) {
+    public function testCheckLanguages(Glossary $ob) {
         $glo = Glossary::get($ob->id);
         $this->assertInstanceOf('Goteo\Model\Glossary', $glo);
-        // $this->assertEquals(self::$data['title'], $glo->title);
         $this->assertEquals(self::$data['description'], $glo->description);
         Lang::set('ca');
         $glo2 = Glossary::get($ob->id);
@@ -170,16 +174,16 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testGetGlossary
      */
-    public function testListing($ob) {
+    public function testListing(Glossary $ob) {
         $list = Glossary::getAll();
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $glo = $list[$ob->id];
         $this->assertInstanceOf('Goteo\Model\Glossary', $glo);
         $this->assertEquals(self::$data['description'], $glo->description);
 
         Lang::set('ca');
         $list = Glossary::getAll();
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $glo2 = $list[$ob->id];
         $this->assertEquals(self::$trans_data['title'], $glo2->title);
         $this->assertEquals(self::$trans_data['description'], $glo2->description);
@@ -190,21 +194,18 @@ class GlossaryTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testGetGlossary
      */
-    public function testDeleteGlossary($ob) {
-        //delete post
+    public function testDeleteGlossary(Glossary $ob)
+    {
         $this->assertTrue($ob->dbDelete());
-
-        return $ob;
     }
+
     public function testCleanProjectRelated() {
         foreach(self::$related_tables as $tb => $field) {
             Glossary::query("DELETE FROM $tb WHERE $field NOT IN (SELECT id FROM glossary)");
             $this->assertEquals(0, Glossary::query("SELECT COUNT(*) FROM $tb WHERE $field NOT IN (SELECT id FROM glossary)")->fetchColumn(), "DB incoherences in table [$tb], Please run SQL command:\nDELETE FROM $tb WHERE $field NOT IN (SELECT id FROM glossary)");
         }
     }
-    /**
-     * Some cleanup
-     */
+
     static function tearDownAfterClass() {
         // Remove temporal files on finish
         unlink(self::$image['tmp_name']);

--- a/tests/Goteo/Model/Location/LocationStatsTest.php
+++ b/tests/Goteo/Model/Location/LocationStatsTest.php
@@ -3,6 +3,7 @@
 
 namespace Goteo\Model\Location\Tests;
 
+use Goteo\Core\DB;
 use Goteo\Model\User;
 use Goteo\Model\Project;
 use Goteo\Model\Location\LocationStats;
@@ -12,12 +13,11 @@ use Goteo\Model\Project\ProjectLocation;
 class LocationStatsTest extends \PHPUnit\Framework\TestCase {
 
     public function testInstance() {
-        \Goteo\Core\DB::cache(false);
+        DB::cache(false);
 
         $stats = new LocationStats(new UserLocation, new User);
 
         $this->assertInstanceOf('\Goteo\Model\Location\LocationStats', $stats);
-
     }
 
     public function testUserStats() {
@@ -29,19 +29,19 @@ class LocationStatsTest extends \PHPUnit\Framework\TestCase {
         $spain = $stats->countFiltered('country_code', 'ES');
         $notSpain = $stats->countFiltered('country_code', 'ES', true);
 
-        $this->assertInternalType('integer', $unlocated);
-        $this->assertInternalType('integer', $located);
+        $this->assertIsInt($unlocated);
+        $this->assertIsInt($located);
         $this->assertEquals(User::dbCount(), $located + $unlocated);
-        $this->assertInternalType('integer', $unlocable);
-        $this->assertInternalType('integer', $notSpain);
+        $this->assertIsInt($unlocable);
+        $this->assertIsInt($notSpain);
         $this->assertEquals($located, $spain + $notSpain);
 
         $spainRegions = $stats->countGroupFiltered('region', 'country_code', 'ES');
-        $this->assertInternalType('array', $spainRegions);
+        $this->assertIsArray($spainRegions);
         $this->assertEquals(array_sum($spainRegions), $spain);
 
         $countries = $stats->countGroupCountries();
-        $this->assertInternalType('array', $countries);
+        $this->assertIsArray($countries);
         $this->assertEquals(array_sum($countries), $located);
     }
 
@@ -54,19 +54,19 @@ class LocationStatsTest extends \PHPUnit\Framework\TestCase {
         $spain = $stats->countFiltered('country_code', 'ES');
         $notSpain = $stats->countFiltered('country_code', 'ES', true);
 
-        $this->assertInternalType('integer', $unlocated);
-        $this->assertInternalType('integer', $located);
+        $this->assertIsInt($unlocated);
+        $this->assertIsInt($located);
         $this->assertEquals(Project::dbCount(), $located + $unlocated);
-        $this->assertInternalType('integer', $unlocable);
-        $this->assertInternalType('integer', $notSpain);
+        $this->assertIsInt($unlocable);
+        $this->assertIsInt($notSpain);
         $this->assertEquals($located, $spain + $notSpain);
 
         $spainRegions = $stats->countGroupFiltered('region', 'country_code', 'ES');
-        $this->assertInternalType('array', $spainRegions);
+        $this->assertIsArray($spainRegions);
         $this->assertEquals(array_sum($spainRegions), $spain);
 
         $countries = $stats->countGroupCountries();
-        $this->assertInternalType('array', $countries);
+        $this->assertIsArray($countries);
         $this->assertEquals(array_sum($countries), $located);
     }
 }

--- a/tests/Goteo/Model/MatcherTest.php
+++ b/tests/Goteo/Model/MatcherTest.php
@@ -289,7 +289,7 @@ class MatcherTest extends TestCase
     public function testListing()
     {
         $list = Matcher::getList();
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $new = end($list);
         $this->assertInstanceOf('Goteo\Model\Matcher', $new);
         $this->assertEquals(self::$data['name'], $new->name);
@@ -297,7 +297,7 @@ class MatcherTest extends TestCase
 
         Lang::set('ca');
         $list = Matcher::getList();
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $new2 = end($list);
         $this->assertEquals(self::$translatedData['name'], $new2->name);
         $this->assertEquals(self::$translatedData['terms'], $new2->terms);

--- a/tests/Goteo/Model/MessageTest.php
+++ b/tests/Goteo/Model/MessageTest.php
@@ -3,6 +3,7 @@
 
 namespace Goteo\Model\Tests;
 
+use Goteo\Core\DB;
 use Goteo\Model\Message;
 use Goteo\Model\User;
 use Goteo\Application\Config;
@@ -20,8 +21,9 @@ class MessageTest extends \PHPUnit\Framework\TestCase {
         Lang::set('es');
     }
 
-    public function testInstance() {
-        \Goteo\Core\DB::cache(false);
+    public function testInstance(): Message
+    {
+        DB::cache(false);
 
         $ob = new Message();
 
@@ -33,7 +35,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testInstance
      */
-    public function testValidate($ob) {
+    public function testValidate(Message $ob) {
         $this->assertFalse($ob->validate());
         $this->assertFalse($ob->save());
     }
@@ -64,7 +66,8 @@ class MessageTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testCreate
      */
-    public function testSaveLanguages($ob) {
+    public function testSaveLanguages(Message $ob): Message
+    {
         $errors = [];
         $this->assertTrue($ob->setLang('ca', self::$trans_data, $errors), print_r($errors, 1));
         return $ob;
@@ -73,7 +76,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testSaveLanguages
      */
-    public function testCheckLanguages($ob) {
+    public function testCheckLanguages(Message $ob) {
         $new = Message::get($ob->id);
         $this->assertInstanceOf('Goteo\Model\Message', $new);
         $this->assertEquals(self::$data['message'], $new->message);
@@ -87,16 +90,16 @@ class MessageTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testCreate
      */
-    public function testListing($ob) {
+    public function testListing(Message $ob) {
         $list = Message::getAll(get_test_project());
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $new = $list[$ob->id];
         $this->assertInstanceOf('Goteo\Model\Message', $new);
         $this->assertEquals(self::$data['message'], $new->message);
 
         Lang::set('ca');
         $list = Message::getAll(get_test_project());
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $new2 = $list[$ob->id];
         $this->assertEquals(self::$trans_data['message'], $new2->message);
         Lang::set('es');
@@ -105,27 +108,23 @@ class MessageTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testCreate
      */
-    public function testDelete($ob) {
+    public function testDelete(Message $ob) {
         $this->assertTrue($ob->dbDelete());
 
         //save and delete statically
         $this->assertTrue($ob->save());
         $this->assertTrue(Message::delete($ob->id));
-
     }
 
     /**
      * @depends testCreate
      */
-    public function testNonExisting($ob) {
+    public function testNonExisting(Message $ob) {
         $ob = Message::get($ob->id);
         $this->assertFalse($ob);
         $this->assertFalse(Message::delete($ob->id));
     }
 
-    /**
-     * Some cleanup
-     */
     static function tearDownAfterClass() {
         delete_test_project();
         delete_test_user();

--- a/tests/Goteo/Model/NodeTest.php
+++ b/tests/Goteo/Model/NodeTest.php
@@ -3,6 +3,7 @@
 
 namespace Goteo\Model\Tests;
 
+use Goteo\Core\DB;
 use Goteo\TestCase;
 use Goteo\Model\Node;
 use Goteo\Model\User;
@@ -36,8 +37,9 @@ class NodeTest extends TestCase {
         Lang::set('es');
     }
 
-    public function testInstance() {
-        \Goteo\Core\DB::cache(false);
+    public function testInstance(): Node
+    {
+        DB::cache(false);
         $ob = new Node();
 
         $this->assertInstanceOf('\Goteo\Model\Node', $ob);
@@ -47,7 +49,7 @@ class NodeTest extends TestCase {
     /**
      * @depends testInstance
      */
-    public function testValidate($ob) {
+    public function testValidate(Node $ob) {
         $this->assertFalse($ob->validate());
         $this->assertFalse($ob->save());
         //delete test node if exists
@@ -67,7 +69,7 @@ class NodeTest extends TestCase {
         $node = new Node(self::$data);
         $this->assertTrue($node->validate($errors), print_r($errors, 1));
         $this->assertNotFalse($node->create($errors), print_r($errors, 1));
-        // die($node->id);
+
         $ob = Node::get($node->id);
         $this->assertInstanceOf('\Goteo\Model\Node', $ob);
         $this->assertEquals($ob->id, self::$data['id']);
@@ -123,7 +125,7 @@ class NodeTest extends TestCase {
      */
     public function testListing($ob) {
         $list = Node::getAll(['id' => $ob->id]);
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $this->assertCount(1, $list);
         $this->assertInstanceOf('Goteo\Model\Node', $list[0]);
         $this->assertEquals(self::$data['subtitle'], $list[0]->subtitle);
@@ -131,7 +133,7 @@ class NodeTest extends TestCase {
 
         Lang::set('ca');
         $list = Node::getAll(['id' => $ob->id]);
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $this->assertCount(1, $list);
 
         $this->assertEquals(self::$trans_data['subtitle'], $list[0]->subtitle);
@@ -228,9 +230,6 @@ class NodeTest extends TestCase {
         }
     }
 
-    /**
-     * Some cleanup
-     */
     static function tearDownAfterClass() {
         delete_test_project();
         delete_test_user();

--- a/tests/Goteo/Model/OpenTagTest.php
+++ b/tests/Goteo/Model/OpenTagTest.php
@@ -3,6 +3,7 @@
 
 namespace Goteo\Model\Tests;
 
+use Goteo\Core\DB;
 use Goteo\Model\OpenTag;
 use Goteo\Application\Config;
 use Goteo\Application\Lang;
@@ -18,8 +19,9 @@ class OpenTagTest extends \PHPUnit\Framework\TestCase {
         Lang::set('es');
     }
 
-    public function testInstance() {
-        \Goteo\Core\DB::cache(false);
+    public function testInstance(): OpenTag
+    {
+        DB::cache(false);
 
         $ob = new OpenTag();
 
@@ -31,7 +33,7 @@ class OpenTagTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testInstance
      */
-    public function testValidate($ob) {
+    public function testValidate(OpenTag $ob) {
         $this->assertFalse($ob->validate(), print_r($errors, 1));
         $this->assertFalse($ob->save());
     }
@@ -53,7 +55,8 @@ class OpenTagTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testCreate
      */
-    public function testSaveLanguages($ob) {
+    public function testSaveLanguages(OpenTag $ob): OpenTag
+    {
         $errors = [];
         $this->assertTrue($ob->setLang('ca', self::$trans_data, $errors), print_r($errors, 1));
         return $ob;
@@ -62,7 +65,7 @@ class OpenTagTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testSaveLanguages
      */
-    public function testCheckLanguages($ob) {
+    public function testCheckLanguages(OpenTag $ob) {
         $new = OpenTag::get($ob->id);
         $this->assertInstanceOf('Goteo\Model\OpenTag', $new);
         $this->assertEquals(self::$data['name'], $new->name);
@@ -77,9 +80,9 @@ class OpenTagTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testCreate
      */
-    public function testListing($ob) {
+    public function testListing(OpenTag $ob) {
         $list = OpenTag::getAll();
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
         $new = $list[$ob->id];
         $this->assertInstanceOf('Goteo\Model\OpenTag', $new);
         $this->assertEquals(self::$data['name'], $new->name);
@@ -87,17 +90,19 @@ class OpenTagTest extends \PHPUnit\Framework\TestCase {
 
         Lang::set('ca');
         $list = OpenTag::getAll();
-        $this->assertInternalType('array', $list);
+        $this->assertIsArray($list);
 
         $new2 = $list[$ob->id];
         $this->assertEquals(self::$trans_data['name'], $new2->name);
         $this->assertEquals(self::$trans_data['description'], $new2->description);
         Lang::set('es');
     }
+
     /**
      * @depends testCreate
      */
-    public function testDelete($ob) {
+    public function testDelete(OpenTag $ob): OpenTag
+    {
         $this->assertTrue($ob->dbDelete());
 
         //save and delete statically
@@ -106,10 +111,11 @@ class OpenTagTest extends \PHPUnit\Framework\TestCase {
 
         return $ob;
     }
+
     /**
      * @depends testDelete
      */
-    public function testNonExisting($ob) {
+    public function testNonExisting(OpenTag $ob) {
         $ob = OpenTag::get($ob->id);
         $this->assertFalse($ob);
         $this->assertFalse(OpenTag::delete($ob->id));

--- a/tests/Goteo/Model/Project/ProjectLocationTest.php
+++ b/tests/Goteo/Model/Project/ProjectLocationTest.php
@@ -3,6 +3,7 @@
 
 namespace Goteo\Model\Project\Tests;
 
+use Goteo\Core\DB;
 use Goteo\Model\Project;
 use Goteo\Model\Project\ProjectLocation;
 use Goteo\Model\User;
@@ -18,8 +19,10 @@ class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
             'longitude' => -0.1234567890,
             'method' => 'ip',
         );
-    public function testInstance() {
-        \Goteo\Core\DB::cache(false);
+
+    public function testInstance(): ProjectLocation
+    {
+        DB::cache(false);
 
         $location = new ProjectLocation();
 
@@ -37,7 +40,8 @@ class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
         $this->assertFalse($location->save());
     }
 
-    public function testAddProjectLocation() {
+    public function testAddProjectLocation(): ProjectLocation
+    {
         self::$data['id'] = 'test-project-non-existing';
         $project_location = new ProjectLocation(self::$data);
         $this->assertInstanceOf('\Goteo\Model\Project\ProjectLocation', $project_location);
@@ -49,24 +53,26 @@ class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($project_location->country_code, self::$data['country_code']);
         $this->assertEquals($project_location->id, self::$data['id']);
 
-
         return $project_location;
     }
+
     /**
      * @depends testAddProjectLocation
      */
-    public function testSaveProjectLocationNonProject($project_location) {
+    public function testSaveProjectLocationNonProject(ProjectLocation $project_location): ProjectLocation
+    {
         delete_test_project();
         delete_test_user();
 
         $this->assertFalse($project_location->save());
         return $project_location;
     }
+
     /**
      * @depends testSaveProjectLocationNonProject
      */
-    public function testCreateProject($project_location) {
-
+    public function testCreateProject(ProjectLocation $project_location): ProjectLocation
+    {
         $user = get_test_user();
         $this->assertInstanceOf('\Goteo\Model\User', $user);
 
@@ -81,7 +87,7 @@ class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testCreateProject
      */
-    public function testSaveProjectLocation($project_location) {
+    public function testSaveProjectLocation(ProjectLocation $project_location) {
         $errors = array();
         $this->assertTrue($project_location->validate($errors), print_r($errors, 1));
         $this->assertTrue($project_location->save($errors), print_r($errors, 1));
@@ -108,7 +114,7 @@ class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends  testSaveProjectLocation
      */
-    public function testSetLocable($project_location) {
+    public function testSetLocable(ProjectLocation $project_location) {
         $errors = array();
         $this->assertTrue($project_location::setLocable($project_location->id, $errors), print_r($errors, 1));
         $project_location2 = ProjectLocation::get($project_location->id);
@@ -142,7 +148,8 @@ class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends  testSetLocable
      */
-    public function testSetProperty($project_location) {
+    public function testSetProperty(ProjectLocation $project_location): ProjectLocation
+    {
         $errors = array();
         $txt = "Test info for location";
         $this->assertTrue($project_location::setProperty($project_location->id, 'info', $txt, $error), print_r($errors, 1));
@@ -157,14 +164,13 @@ class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testSaveProjectLocation
      */
-    public function testNearbyEmpty($project_location) {
-        $errors = array();
+    public function testNearbyEmpty(ProjectLocation $project_location) {
         $project = new Project;
         $loc = new ProjectLocation($project);
         $this->assertInstanceOf('\Goteo\Model\Project\ProjectLocation', $loc);
-        $sibilings = $loc->getSibilingsNearby();
-        $this->assertInternalType('array', $sibilings);
-        $this->assertEmpty($sibilings);
+        $siblings = $loc->getSibilingsNearby();
+        $this->assertIsArray($siblings);
+        $this->assertEmpty($siblings);
 
         return $project_location;
     }
@@ -172,17 +178,16 @@ class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testNearbyEmpty
      */
-    public function testNearbyEmptyProjects($project_location) {
-
+    public function testNearbyEmptyProjects() {
         $projects_nearby = ProjectLocation::getNearby(new UserLocation, 1);
-        $this->assertInternalType('array', $projects_nearby);
+        $this->assertIsArray($projects_nearby);
         $this->assertEmpty($projects_nearby);
     }
 
     /**
      * @depends testNearbyEmpty
      */
-    public function testNearby($project_location) {
+    public function testNearby(ProjectLocation $project_location) {
         // create location for user
         $data = self::$data;
         $user = get_test_user();
@@ -194,32 +199,25 @@ class ProjectLocationTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue($user_location->save($errors), print_r($errors, 1));
 
         $projects_nearby = ProjectLocation::getNearby($user_location, 100);
-        // print_r($projects_nearby);die;
-        $this->assertInternalType('array', $projects_nearby);
+        $this->assertIsArray($projects_nearby);
         $keys = array();
         foreach($projects_nearby as $ob) {
             $this->assertInstanceOf('\Goteo\Model\Project\Projectlocation', $ob);
             $keys[] = $ob->id;
         }
         $this->assertContains($project_location->id, $keys);
-
     }
 
     /**
      * @depends  testSetProperty
      */
-    public function testRemoveAddLocationEntry($project_location) {
-
+    public function testRemoveAddLocationEntry(ProjectLocation $project_location) {
         $this->assertTrue($project_location->dbDelete());
         $project_location2 = ProjectLocation::get($project_location->id);
 
         $this->assertFalse($project_location2);
-
     }
 
-    /**
-     * Some cleanup
-     */
     static function tearDownAfterClass() {
         delete_test_project();
         delete_test_user();

--- a/tests/Goteo/Model/User/UserLocationTest.php
+++ b/tests/Goteo/Model/User/UserLocationTest.php
@@ -2,6 +2,7 @@
 
 namespace Goteo\Model\User\Tests;
 
+use Goteo\Core\DB;
 use Goteo\Model\User;
 use Goteo\Model\User\UserLocation;
 
@@ -16,8 +17,9 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
             'method' => 'ip'
         );
 
-    public function testInstance() {
-        \Goteo\Core\DB::cache(false);
+    public function testInstance(): UserLocation
+    {
+        DB::cache(false);
 
         $location = new UserLocation();
 
@@ -30,13 +32,14 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
      *
      * @depends testInstance
      */
-    public function testDefaultValidation($location) {
+    public function testDefaultValidation(UserLocation $location) {
         $this->assertFalse($location->validate($errors));
         $this->assertFalse($location->save());
         delete_test_user();
     }
 
-    public function testAddUserLocation() {
+    public function testAddUserLocation(): UserLocation
+    {
         self::$data['id'] = 'test-user-non-existing';
         $user_location = new UserLocation(self::$data);
         $this->assertInstanceOf('\Goteo\Model\User\UserLocation', $user_location);
@@ -55,7 +58,8 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testAddUserLocation
      */
-    public function testSaveUserLocationNonUser($user_location) {
+    public function testSaveUserLocationNonUser(UserLocation $user_location): UserLocation
+    {
         $this->assertFalse($user_location->save());
         return $user_location;
     }
@@ -63,7 +67,8 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testSaveUserLocationNonUser
      */
-    public function testCreateUser($user_location) {
+    public function testCreateUser(UserLocation $user_location): UserLocation
+    {
         $user = get_test_user();
         $this->assertInstanceOf('\Goteo\Model\User', $user);
         self::$data['id'] = $user->id;
@@ -74,7 +79,7 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testCreateUser
      */
-    public function testSaveUserLocation($user_location) {
+    public function testSaveUserLocation(UserLocation $user_location) {
         $errors = array();
         $this->assertTrue($user_location->validate($errors), print_r($errors, 1));
         $this->assertTrue($user_location->save($errors), print_r($errors, 1));
@@ -101,7 +106,8 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends  testSaveUserLocation
      */
-    public function testSetLocable($user_location) {
+    public function testSetLocable(UserLocation $user_location): UserLocation
+    {
         $errors = array();
         $this->assertTrue($user_location::setLocable($user_location->id, $errors), print_r($errors, 1));
         $user_location2 = UserLocation::get($user_location->id);
@@ -133,7 +139,8 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends  testSetLocable
      */
-    public function testSetProperty($user_location) {
+    public function testSetProperty(UserLocation $user_location): UserLocation
+    {
         $errors = array();
         $txt = "Test info for location";
         $this->assertTrue($user_location::setProperty($user_location->id, 'info', $txt, $error), print_r($errors, 1));
@@ -147,20 +154,20 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testSaveUserLocation
      */
-    public function testNearbyEmpty($user_location) {
-        $errors = array();
+    public function testNearbyEmpty() {
         $user = new User;
         $loc = new UserLocation($user);
         $this->assertInstanceOf('\Goteo\Model\User\UserLocation', $loc);
-        $sibilings = $loc->getSibilingsNearby();
-        $this->assertInternalType('array', $sibilings);
-        $this->assertEmpty($sibilings);
+        $siblings = $loc->getSibilingsNearby();
+        $this->assertIsArray($siblings);
+        $this->assertEmpty($siblings);
     }
 
     /**
      * @depends testSaveUserLocation
      */
-    public function testAddSecondUser($user_location) {
+    public function testAddSecondUser(UserLocation $user_location): array
+    {
         $errors = array();
         $user = get_test_user();
         $usr['userid'] = '012-second-test-user-210';
@@ -188,13 +195,11 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
      * @depends testAddSecondUser
      */
     public function testNearby(array $users) {
-        $errors = array();
         list($user1, $user2) = $users;
-        $sibilings = $user1->getSibilingsNearby(100);
-        // print_r($sibilings);
-        $this->assertInternalType('array', $sibilings);
+        $siblings = $user1->getSibilingsNearby(100);
+        $this->assertIsArray($siblings);
         $keys = array();
-        foreach($sibilings as $ob) {
+        foreach($siblings as $ob) {
             $this->assertInstanceOf('\Goteo\Model\User\Userlocation', $ob);
             $keys[] = $ob->id;
         }
@@ -207,18 +212,13 @@ class UserLocationTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends  testSetProperty
      */
-    public function testRemoveLocationEntry($user_location) {
-        $errors = array();
+    public function testRemoveLocationEntry(UserLocation $user_location) {
         $this->assertTrue($user_location->dbDelete());
         $user_location2 = UserLocation::get($user_location->id);
 
         $this->assertFalse($user_location2);
-
     }
 
-    /**
-     * Some cleanup
-     */
     static function tearDownAfterClass() {
         if($user = User::get('012-second-test-user-210')) {
             $user->dbDelete();

--- a/tests/Goteo/Model/User/UserRolesTest.php
+++ b/tests/Goteo/Model/User/UserRolesTest.php
@@ -3,6 +3,7 @@
 
 namespace Goteo\Model\User\Tests;
 
+use Exception;
 use Goteo\Model\User;
 use Goteo\Model\User\UserRoles;
 
@@ -48,7 +49,7 @@ class UserRolesTest extends \PHPUnit\Framework\TestCase {
         try {
             // Role root cannot be added
             $roles->addRole('root');
-        } catch(\Exception $e) {
+        } catch(Exception $e) {
             $this->assertInstanceOf('Goteo\Application\Exception\RoleException', $e);
         }
         $this->assertFalse($roles->hasRole('root'));
@@ -59,7 +60,7 @@ class UserRolesTest extends \PHPUnit\Framework\TestCase {
      * @depends testAddRoles
      */
     public function testRoleNames($roles) {
-        $this->assertInternalType('array', $roles->getRoleNames());
+        $this->assertIsArray($roles->getRoleNames());
         $this->assertArrayHasKey('user', $roles->getRoleNames(), print_r($roles->getRoleNames(), 1));
         $this->assertArrayHasKey('admin', $roles->getRoleNames());
     }
@@ -76,7 +77,7 @@ class UserRolesTest extends \PHPUnit\Framework\TestCase {
         try {
             // Role user cannot be removed
             $roles->removeRole('user');
-        } catch(\Exception $e) {
+        } catch(Exception $e) {
             $this->assertInstanceOf('Goteo\Application\Exception\RoleException', $e);
         }
         $this->assertTrue($roles->hasRole('user'));
@@ -97,7 +98,7 @@ class UserRolesTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testPersistence
      */
-    public function testCheckPersistence($roles) {
+    public function testCheckPersistence() {
         $new = UserRoles::getRolesForUser(get_test_user());
         $this->assertInstanceOf('Goteo\Model\User\UserRoles', $new);
         $this->assertTrue($new->hasRole('user'));

--- a/tests/Goteo/Model/UserTest.php
+++ b/tests/Goteo/Model/UserTest.php
@@ -46,8 +46,8 @@ class UserTest extends TestCase {
             'email' => 'simulated-user-test2@goteo.org'
         );
 
-    public function testInstance() {
-
+    public function testInstance(): User
+    {
         $converter = new User();
 
         $this->assertInstanceOf('\Goteo\Model\User', $converter);
@@ -62,9 +62,9 @@ class UserTest extends TestCase {
         $nolocation = $total - User::dbCount(array('location' => ''), '!=');
         $mainnode = User::dbCount(array('node' => 'goteo'));
 
-        $this->assertInternalType('integer', $total);
-        $this->assertInternalType('integer', $active);
-        $this->assertInternalType('integer', $mainnode);
+        $this->assertIsInt($total);
+        $this->assertIsInt($active);
+        $this->assertIsInt($mainnode);
         $this->assertGreaterThanOrEqual($active, $total);
         $this->assertGreaterThanOrEqual($nolocation, $total);
         $this->assertGreaterThanOrEqual($mainnode, $total);
@@ -85,9 +85,9 @@ class UserTest extends TestCase {
     /**
      * @depends testCreateUser
      */
-    public function testSuggestUserId($user) {
+    public function testSuggestUserId() {
         $suggestions = User::suggestUserId("I hope this user does not exists");
-        $this->assertInternalType('array', $suggestions);
+        $this->assertIsArray($suggestions);
         $this->assertGreaterThanOrEqual(1, count($suggestions));
         $this->assertEquals('ihope', $suggestions[0]);
         $suggestions = User::suggestUserId("IHopeThisUserDoesNotexists:👑");

--- a/tests/Goteo/Payment/PaymentTest.php
+++ b/tests/Goteo/Payment/PaymentTest.php
@@ -11,14 +11,13 @@ class MockPaymentMethod extends AbstractPaymentMethod {
 
 class PaymentTest extends \PHPUnit\Framework\TestCase {
 
-    public function testInstance() {
-
+    public function testInstance(): Payment
+    {
         $ob = new Payment();
 
         $this->assertInstanceOf('Goteo\Payment\Payment', $ob);
 
         return $ob;
-
     }
 
     public function testAddMethod() {
@@ -34,9 +33,10 @@ class PaymentTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue(Payment::methodExists('mock'));
     }
 
-    public function testGetMethods() {
+    public function testGetMethods(): array
+    {
         $methods = Payment::getMethods();
-        $this->assertInternalType('array', $methods);
+        $this->assertIsArray($methods);
         $this->assertArrayHasKey('mock', $methods);
         $methods = Payment::getMethods(get_test_user());
         $this->assertContainsOnlyInstancesOf('Goteo\Payment\Method\PaymentMethodInterface', $methods);
@@ -50,7 +50,7 @@ class PaymentTest extends \PHPUnit\Framework\TestCase {
     /**
      * @depends testGetMethods
      */
-    public function testDefaultMethod($methods) {
+    public function testDefaultMethod() {
         Payment::defaultMethod('mock');
         $this->assertEquals('mock', Payment::defaultMethod());
     }


### PR DESCRIPTION
Changes within this PR:

- PHPUnit upgraded to 7.x
- PHP min version is now 7.1 (because it's the minimum required version for PHPUnit 7.x)
- Updated deprecated methods on PHPUnit 7.x
- Added many parameter and return types

All tests continue in green.

INFO: PHP versions performance report: https://kinsta.com/blog/php-benchmarks/