### PR TITLE
Bug/fix goteo private plugin autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "autoload": {
         "psr-4": {
-            "": ["src/"]
+            "": ["src/", "extend/goteo-private/src"]
         }
     },
     "require-dev": {

--- a/src/Goteo/Console/EventListener/ConsoleWatcherListener.php
+++ b/src/Goteo/Console/EventListener/ConsoleWatcherListener.php
@@ -240,22 +240,6 @@ class ConsoleWatcherListener extends AbstractListener {
                 }
                 break;
 
-            case 9:
-                // TODO: to extend/...
-                // Busca prescriptores e implícalos
-                // si no tiene padrinos
-                if(class_exists('\Goteo\Model\Patron')) {
-                    // número de recomendaciones de padrinos
-                    $patrons = \Goteo\Model\Patron::numRecos($project->id);
-
-                    if ($patrons > 0) {
-                        $this->warning("Not sending message to project as already has patrons", [$project, 'days_active' => $days_active, 'days_funded' => $days_funded]);
-                    } else {
-                        $this->send($project, "tip_9", ['owner']);
-                    }
-                }
-                break;
-
             case 10: // Luce tus recompensas y retornos
                 // que no se envie a los que solo tienen recompensas de agradecimiento
                 $thanksonly = true;


### PR DESCRIPTION
This PR is needed to re-enable the Goteo private plugin tests.

Basically we are adding the goteo-private src folder so it's taken into account to load the classes and the tests can be executed correctly. If the goteo-private plugin isn't included, nothing wrong will happen while running the tests.

A case from a class has been removed as well, as it was agreed that that class wasn't needed anymore.