### PR TITLE
Upgrade Grunt and grunt-contrib-uglify

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -36,7 +36,7 @@ RUN mv composer.phar /usr/local/bin/composer
 
 RUN gem install sass -v 3.4.23
 RUN gem install compass
-RUN npm install -g grunt-cli@1.3.2
+RUN npm install -g grunt-cli
 
 # PHP-FPM packages need a nudge to make them docker-friendly
 COPY overrides.conf /etc/php/${PHP_VERSION}/fpm/pool.d/z-overrides.conf

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -36,7 +36,7 @@ RUN mv composer.phar /usr/local/bin/composer
 
 RUN gem install sass -v 3.4.23
 RUN gem install compass
-RUN npm install -g grunt-cli
+RUN npm install -g grunt-cli@1.4.0
 
 # PHP-FPM packages need a nudge to make them docker-friendly
 COPY overrides.conf /etc/php/${PHP_VERSION}/fpm/pool.d/z-overrides.conf

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-contrib-imagemin": "^1.0.1",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-sass": "^1.0.0",
-    "grunt-contrib-uglify": "^3.1.0",
+    "grunt-contrib-uglify": "^4.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-filerev": "^2.1.1",
     "grunt-newer": "^1.2.0",


### PR DESCRIPTION
Upgrade grunt inside our Dockerfile images since we don't have the limitation of the old ubuntu 16.04 distribution. Since with the Ubuntu 18.04 image we have node 8.0 we can upgrade the Grunt version we are using.

This also allows us to upgrade the uglify minifier that we were using so that it understands ES6.

This PR is related to #223 