### PR TITLE
Fix deprecated call of implode function

### DIFF
--- a/Resources/templates/responsive/channel/call/partials/map.php
+++ b/Resources/templates/responsive/channel/call/partials/map.php
@@ -21,7 +21,7 @@ if($this->projects || $section):
   }
 
   if ($map_config['center']) {
-    $url .= '/' . implode($map_config['center'],',');
+    $url .= '/' . implode(',', $map_config['center']);
   }
 
 


### PR DESCRIPTION
Since PHP7.4 " Passing the separator after the array (i.e. using the legacy signature) has been deprecated. "
so this PR fixes it.
