### PR TITLE
Display cursor at current tab projects' button on homepage

### DIFF
--- a/public/assets/sass/misc/_misc.scss
+++ b/public/assets/sass/misc/_misc.scss
@@ -201,7 +201,6 @@ ul.project-filters {
       background-color: $background-light-green;
       border-radius: 5px;
       color: $color-white !important;
-      cursor: none;
       a {
         color: $color-white !important;
       }


### PR DESCRIPTION
Attach you'll find a screenshot where you see the highlighted tab "Favorits de l'equip". If you move the mouse cursor over it, before this PR, you will see the cursor is hidden (which makes the UX very weird in my opinion).

With this PR, the cursor is shown as normal.

![image](https://user-images.githubusercontent.com/19690868/134016221-37d37000-0cc9-4100-ad62-3ff61a7f2752.png)
