### PR TITLE
Hide project signature fields

### DIFF
--- a/Resources/templates/responsive/dashboard/project/overview.php
+++ b/Resources/templates/responsive/dashboard/project/overview.php
@@ -22,3 +22,26 @@
 </div>
 
 <?php $this->replace() ?>
+
+<?php $this->section('footer') ?>
+<script>
+
+$(function(){
+  $('#autoform_sign_check').change(function() {
+    $('#form-sign_url').toggleClass('hidden');
+    $('#form-sign_url_action').toggleClass('hidden');
+
+    if (! $(this).is(':checked') ) {
+      $('#autoform_sign_url').val('');
+      $('#autoform_sign_url').prop('required', false);
+      $('#autoform_sign_url_action').val('');
+      $('#autoform_sign_url_action').prop('required', false);
+    } else {
+      $('#autoform_sign_url').prop('required', true);
+      $('#autoform_sign_url_action').prop('required', true);
+    }
+  })
+});
+
+</script>
+<?php $this->append() ?>

--- a/Resources/translations/ca/overview.yml
+++ b/Resources/translations/ca/overview.yml
@@ -81,7 +81,7 @@ overview-field-sustainability-model: 'Model de sostenibilitat'
 overview-field-sustainability-model-url: 'URL del teu business canvas'
 tooltip-project-sustainability-model: 'Explica el model de sostenibilitat del teu projecte'
 tooltip-project-sustainability-model-url: 'Afegeix una url amb teu <a href="https://canvanizer.com/new/business-model-canvas" target="_blank">business canvas</a>'
-overview-field-sign-check: 'Tinc una campanya de signatures online'
+overview-field-sign-check: 'Tens una recollida de signatures oberta relacionada amb el projecte?'
 overview-field-sign-url: "Url per signar"
 overview-field-sign-url-action: "Text per fer una crida a signar"
-overview-field-sign-url-help: "Aquest camp et permet afegir un salt cap a la teva pàgina de recollida de signatures"
+overview-field-sign-url-help: "Si paral·lelament a la campanya a Goteo tens una campanya de recollida de signatures en una altra plataforma, pots afegir aquí un botó amb enllaç"

--- a/Resources/translations/ca/overview.yml
+++ b/Resources/translations/ca/overview.yml
@@ -81,6 +81,7 @@ overview-field-sustainability-model: 'Model de sostenibilitat'
 overview-field-sustainability-model-url: 'URL del teu business canvas'
 tooltip-project-sustainability-model: 'Explica el model de sostenibilitat del teu projecte'
 tooltip-project-sustainability-model-url: 'Afegeix una url amb teu <a href="https://canvanizer.com/new/business-model-canvas" target="_blank">business canvas</a>'
+overview-field-sign-check: 'Tinc una campanya de signatures online'
 overview-field-sign-url: "Url per signar"
 overview-field-sign-url-action: "Text per fer una crida a signar"
 overview-field-sign-url-help: "Aquest camp et permet afegir un salt cap a la teva pàgina de recollida de signatures"

--- a/Resources/translations/en/overview.yml
+++ b/Resources/translations/en/overview.yml
@@ -78,7 +78,7 @@ overview-field-sustainability-model: 'Sustainability plan'
 overview-field-sustainability-model-url: 'URL of your business canvas'
 tooltip-project-sustainability-model: 'Present a basic business plan to show how you will ensure project''s sustainability. The business plan should cover the key elements of the business canvas template and be no longer than two pages.'
 tooltip-project-sustainability-model-url: 'Add the URL of your <a href="https://canvanizer.com/new/business-model-canvas" target="_blank">business canvas</a>'
-overview-field-sign-check: 'I have an online signature campaign'
+overview-field-sign-check: 'Do you have an open signature collection related to the project?'
 overview-field-sign-url: "Singature Url"
 overview-field-sign-url-action: "Text to call for signature"
-overview-field-sign-url-help: "This field allows you to add a redirection to your project signature page"
+overview-field-sign-url-help: "If in parallel to the campaign on Goteo you have a signature campaign on another platform, you can add a button with a link here"

--- a/Resources/translations/en/overview.yml
+++ b/Resources/translations/en/overview.yml
@@ -78,6 +78,7 @@ overview-field-sustainability-model: 'Sustainability plan'
 overview-field-sustainability-model-url: 'URL of your business canvas'
 tooltip-project-sustainability-model: 'Present a basic business plan to show how you will ensure project''s sustainability. The business plan should cover the key elements of the business canvas template and be no longer than two pages.'
 tooltip-project-sustainability-model-url: 'Add the URL of your <a href="https://canvanizer.com/new/business-model-canvas" target="_blank">business canvas</a>'
+overview-field-sign-check: 'I have an online signature campaign'
 overview-field-sign-url: "Singature Url"
 overview-field-sign-url-action: "Text to call for signature"
 overview-field-sign-url-help: "This field allows you to add a redirection to your project signature page"

--- a/Resources/translations/es/overview.yml
+++ b/Resources/translations/es/overview.yml
@@ -84,6 +84,7 @@ tooltip-project-sustainability-model: 'Explica el modelo de sostenibilidad de tu
 tooltip-project-sustainability-model-url: 'Agrega una url con tu <a href="https://canvanizer.com/new/business-model-canvas" target="_blank">business canvas</a>'
 tooltip-project-sdg: 'Elige los objetivos con los que cumple tu proyecto, intentando seleccionar un máximo de tres.'
 tooltip-project-sdg-suggestion: 'A continuación te sugerimos algunos ODS que podrían encajar según el compromiso social seleccionado para tu proyecto, te recomendamos que consultes <a href="https://www.un.org/sustainabledevelopment/es/objetivos-de-desarrollo-sostenible/" target="_blank">aquí</a> su contenido especifico.<br><br>'
+overview-field-sign-check: 'Tengo una campaña de firmas online'
 overview-field-sign-url: "Url de firma"
 overview-field-sign-url-action: "Texto para llamar a firmar"
 overview-field-sign-url-help: "Este campo permite añadir un salto en la campaña para tu página de firmas del proyecto"

--- a/Resources/translations/es/overview.yml
+++ b/Resources/translations/es/overview.yml
@@ -84,7 +84,7 @@ tooltip-project-sustainability-model: 'Explica el modelo de sostenibilidad de tu
 tooltip-project-sustainability-model-url: 'Agrega una url con tu <a href="https://canvanizer.com/new/business-model-canvas" target="_blank">business canvas</a>'
 tooltip-project-sdg: 'Elige los objetivos con los que cumple tu proyecto, intentando seleccionar un máximo de tres.'
 tooltip-project-sdg-suggestion: 'A continuación te sugerimos algunos ODS que podrían encajar según el compromiso social seleccionado para tu proyecto, te recomendamos que consultes <a href="https://www.un.org/sustainabledevelopment/es/objetivos-de-desarrollo-sostenible/" target="_blank">aquí</a> su contenido especifico.<br><br>'
-overview-field-sign-check: 'Tengo una campaña de firmas online'
+overview-field-sign-check: '¿Tienes una recogida de firmas abierta relacionada con el proyecto?'
 overview-field-sign-url: "Url de firma"
 overview-field-sign-url-action: "Texto para llamar a firmar"
-overview-field-sign-url-help: "Este campo permite añadir un salto en la campaña para tu página de firmas del proyecto"
+overview-field-sign-url-help: "Si paralelamente a la campaña en Goteo tienes una campaña de recogida de firmas en otra plataforma, puedes añadir aquí un botón con enlace"

--- a/src/Goteo/Library/Forms/Model/ProjectOverviewForm.php
+++ b/src/Goteo/Library/Forms/Model/ProjectOverviewForm.php
@@ -273,7 +273,7 @@ class ProjectOverviewForm extends AbstractFormProcessor implements FormProcessor
                 'data' => $model->sign_url,
                 'row_class' => $model->sign_url && $model->sign_url_action ? '' : 'hidden',
                 'attr' => [
-                    'pre-help' => Text::get('overview-field-sign-url-help')
+                    'help' => Text::get('overview-field-sign-url-help')
                 ]
             ])
 

--- a/src/Goteo/Library/Forms/Model/ProjectOverviewForm.php
+++ b/src/Goteo/Library/Forms/Model/ProjectOverviewForm.php
@@ -26,6 +26,9 @@ use Goteo\Model\Sdg;
 
 use Goteo\Util\Form\Type\TextType;
 use Goteo\Util\Form\Type\UrlType;
+use Goteo\Util\Form\Type\BooleanType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+
 
 
 class ProjectOverviewForm extends AbstractFormProcessor implements FormProcessorInterface {
@@ -257,9 +260,18 @@ class ProjectOverviewForm extends AbstractFormProcessor implements FormProcessor
                 'attr' => ['help' => Text::get('tooltip-project-social-description'), 'rows' => 8]
             ])
 
+            ->add('sign_check', BooleanType::class, [
+                'label' => 'overview-field-sign-check', // 'overview-field-sign-check',
+                'required' => false,
+                'data' => $model->sign_url && $model->sign_url_action ? true : false,
+                'mapped' => false
+            ])
+
             ->add('sign_url', UrlType::Class, [
                 'label' => 'overview-field-sign-url',
                 'required' => false,
+                'data' => $model->sign_url,
+                'row_class' => $model->sign_url && $model->sign_url_action ? '' : 'hidden',
                 'attr' => [
                     'pre-help' => Text::get('overview-field-sign-url-help')
                 ]
@@ -267,7 +279,9 @@ class ProjectOverviewForm extends AbstractFormProcessor implements FormProcessor
 
             ->add('sign_url_action', TextType::class, [
                 'label' => 'overview-field-sign-url-action',
-                'required' => false
+                'required' => false,
+                'data' => $model->sign_url_action,
+                'row_class' => $model->sign_url && $model->sign_url_action ? '' : 'hidden'
             ])
             ;
 

--- a/tests/Goteo/Model/FaqTest.php
+++ b/tests/Goteo/Model/FaqTest.php
@@ -40,8 +40,9 @@ class FaqTest extends TestCase {
 
     public function testCreate() {
         self::$data['node'] = get_test_node()->id;
+        $errors = [];
         $ob = new Faq(self::$data);
-        $this->assertTrue($ob->validate($errors));
+        $this->assertTrue($ob->validate($errors), implode(',',$errors));
         $this->assertTrue($ob->save());
         $ob = Faq::get($ob->id);
         $this->assertInstanceOf('\Goteo\Model\Faq', $ob);


### PR DESCRIPTION
# What 

Hide the fields related to the project's signature platform.

# Why

The fields we added in #234 are being used by project owners to just redirect to their own web pages. That is not the use we were expecting. We want the user to have to check an input checkbox saying they have an open campaign to collect signatures.

# How

We add a checkbox that toggles the input fields for the platform url.