### PR TITLE
Fix image display width inside Project's Social Commitment Section

### DIFF
--- a/public/assets/sass/project.scss
+++ b/public/assets/sass/project.scss
@@ -719,6 +719,9 @@ div {
       font-size: 13px;
       font-weight: bold;
     }
+    img {
+      max-width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
The images that were being added in the markdown for the Social Commitment section inside a project landing could expand outside the section box.﻿
