### PR TITLE
Remove project's D3 end of round marker

### DIFF
--- a/Resources/templates/responsive/project/partials/chart_amount.php
+++ b/Resources/templates/responsive/project/partials/chart_amount.php
@@ -199,7 +199,11 @@ function printAmount() {
         };
       });
 
-      var markers = [{date:parseDate('<?= $this->project->willpass ?>'),type:"<?= $this->text('project-chart-amount-end-round') ?>" , version: "1"}];
+      var markers = [];
+
+      <?php if (!$this->project->one_round): ?>
+        markers = [{date:parseDate('<?= $this->project->willpass ?>'),type:"<?= $this->text('project-chart-amount-end-round') ?>" , version: "1"}];
+      <?php endif; ?>
 
       makeChart(data, markers);
 


### PR DESCRIPTION
This PR removes d3  end of round marker in project participate section when there is only one round