### PR TITLE
Fix Message function to retrieve participants

### DIFF
--- a/src/Goteo/Model/Message.php
+++ b/src/Goteo/Model/Message.php
@@ -531,7 +531,8 @@ class Message extends \Goteo\Core\Model {
         if(!$this->participants) {
             $sql = "SELECT DISTINCT user.* FROM `user`
                 RIGHT JOIN message a ON a.user = user.id
-                WHERE a.thread IN ( SELECT id FROM message b WHERE b.id = :id )";
+                WHERE a.thread IN ( SELECT id FROM message b WHERE b.id = :id )
+                    OR a.id = :id";
 
             $query = self::query($sql, [':id' => $this->id]);
             $this->participants = $this->getRecipients();


### PR DESCRIPTION
The Message function getParticipants was not retrieving the owner of threads, only the users that were participating in the thread. Now it includes the owner (then it makes the optional variable with_author useful)﻿
