### PR TITLE
Create Invest Address model and form

### DIFF
--- a/Resources/templates/responsive/pool/user_data.php
+++ b/Resources/templates/responsive/pool/user_data.php
@@ -14,13 +14,9 @@ $this->section('dashboard-content-pool');
 
     <?= $this->supply('sub-header', $this->get_session('sub-header')) ?>
 
-    <form class="form" id="make-sure-form" role="form" method="POST" action="<?= '/'.$this->type.'/'.$this->invest->id ?>">
+    <h3 class="clear-both padding-bottom-2 clear-both"><?= $this->text('invest-address-title') ?></h3>
 
-        <?= $this->supply('invest-form', $this->insert('invest/partials/invest_address_form')) ?>
-
-        <?= $this->insert('invest/partials/invest_submit_form') ?>
-
-	</form>
+    <?= $this->form_form($this->raw('form')); ?>
 
 </div>
 

--- a/src/Goteo/Controller/PoolController.php
+++ b/src/Goteo/Controller/PoolController.php
@@ -18,17 +18,21 @@ use Goteo\Application\Currency;
 use Goteo\Application\Event\FilterInvestFinishEvent;
 use Goteo\Application\Event\FilterInvestInitEvent;
 use Goteo\Application\Event\FilterInvestRequestEvent;
+use Goteo\Application\Exception\ModelNotFoundException;
 use Goteo\Application\Message;
 use Goteo\Application\Session;
 use Goteo\Application\View;
 use Goteo\Core\Controller;
+use Goteo\Library\Forms\Model\InvestAddressForm;
 use Goteo\Library\Text;
 use Goteo\Model\Invest;
+use Goteo\Model\Invest\InvestAddress;
 use Goteo\Model\Project;
 use Goteo\Model\User;
 use Goteo\Model\User\Donor;
 use Goteo\Payment\Payment;
 use Goteo\Payment\PaymentException;
+use Goteo\Repository\Invest\AddressRepository;
 use Omnipay\Common\Message\ResponseInterface;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
@@ -334,6 +338,22 @@ class PoolController extends Controller {
         // check post data
         $invest_address = (array)$invest->getAddress();
 
+        try {
+            $investAddress = InvestAddress::getByInvest($invest->id);
+        } catch (ModelNotFoundException $e) {
+
+            $investAddress = new InvestAddress();
+            $address = $invest->getAddress();
+            $investAddress
+                ->setInvest($invest->id)
+                ->setName($address->name)
+                ->setNif($address->nif)
+                ->setAddress($address->address)
+                ->setLocation($address->location)
+                ->setZipcode($address->zipcode)
+                ->setCountry($address->country);
+        }
+
         $errors = [];
         if($request->isMethod('post')) {
             return $this->dispatch(
@@ -342,6 +362,11 @@ class PoolController extends Controller {
             )->getHttpResponse();
         }
 
+        $processor = $this->getModelForm(InvestAddressForm::class, $investAddress, (array)$investAddress, [], $request);
+        $processor->createForm();
+        $processor->getBuilder();
+        $form = $processor->getForm();
+        $form->handleRequest($request);
         return $this->viewResponse('pool/user_data', [
             'type' => $type,
             'invest' => $invest,
@@ -349,7 +374,8 @@ class PoolController extends Controller {
             'invest_errors' => $errors,
             'step' => 3,
             'legal_entities' => Donor::getLegalEntities(),
-            'legal_documents' => Donor::getLegalDocumentTypes()
+            'legal_documents' => Donor::getLegalDocumentTypes(),
+            'form' => $form->createView()
         ]);
     }
 

--- a/src/Goteo/Library/Forms/Model/InvestAddressForm.php
+++ b/src/Goteo/Library/Forms/Model/InvestAddressForm.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Goteo\Library\Forms\Model;
+
+use Goteo\Application\Lang;
+use Goteo\Library\Forms\AbstractFormProcessor;
+use Goteo\Library\Forms\FormProcessorInterface;
+use Goteo\Library\Text;
+use Goteo\Util\Form\Type\ChoiceType;
+use Goteo\Util\Form\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormInterface;
+
+class InvestAddressForm extends AbstractFormProcessor implements FormProcessorInterface {
+
+    public function createForm(): InvestAddressForm
+    {
+        $model = $this->getModel();
+
+        $this->getBuilder()
+            ->add('legal_entity', ChoiceType::class,[
+                'label' => 'invest-address-legal-entity-field',
+                'attr' => [
+                    'id' => 'fiscal-legal-entity',
+                    'placeholder' => 'regular-choice-placeholder'
+                ],
+                'choices' => [
+                    Text::get('donor-legal-entities-natural-person') => 'natural_person',
+                    Text::get('donor-legal-entities-legal-person') => 'legal_person'
+                ]
+            ])
+            ->add('name', TextType::class, [
+                'label' => 'personal-field-donor_name',
+                'attr' => [
+                    'placeholder' => 'personal-field-donor_name'
+                ],
+                'required' => true
+            ])
+            ->add('surname', TextType::class, [
+                'label' => 'personal-field-donor_surname',
+                'attr' => [
+                    'placeholder' => 'personal-field-donor_surname'
+                ]
+            ])->add('surname2', TextType::class, [
+                'label' => 'personal-field-donor_surname2',
+                'attr' => [
+                    'placeholder' => 'personal-field-donor_surname2'
+                ]
+            ])
+            ->add('gender', ChoiceType::class, [
+                'choices' => [
+                    'regular-male' => 'M',
+                    'regular-female' => 'F',
+                    'regular-other-gender' => 'O'
+                ],
+                'expanded' => true
+            ])
+            ->add('birthyear', ChoiceType::class, [
+                'label' => 'invest-address-birthyear-field',
+                'attr' => [
+                    'placeholder' => 'invest-address-birthyear-field'
+                ],
+                'choices' => array_combine(range(date('Y') - 14, date('Y') - 100 ), range(date('Y') - 14, date('Y') - 100 ))
+            ])
+            ->add('legal_document_type', ChoiceType::class, [
+                'label' => 'invest-address-legal-document-type-field',
+                'attr' => [
+                    'id' => 'fiscal-legal-document-type',
+                    'placeholder' => 'invest-address-legal-document-type-field'
+                ],
+                'choices' => [
+                    'cif' => Text::get('donor-legal-document-type-cif'),
+                    'nif' => Text::get('donor-legal-document-type-nif'),
+                    'nie' => Text::get('donor-legal-document-type-nie')
+                ]
+            ])
+            ->add('nif', TextType::class, [
+                'label' => 'invest-address-nif-field',
+                'attr' => [
+                    'placeholder' => 'invest-address-nif-field'
+                ],
+                'required' => true
+            ])
+            ->add('address', TextType::class, [
+                'label' => 'invest-address-address-field',
+                'required' => true,
+                'attr' => [
+                    'id' => 'fiscal-address',
+                    'class' => 'form-control geo-autocomplete',
+                    "data-geocoder-populate-address" => "#fiscal-address",
+                    "data-geocoder-populate-city" => "#fiscal-location",
+                    "data-geocoder-populate-region" => "#fiscal-region",
+                    "data-geocoder-populate-zipcode" => "#fiscal-zipcode",
+                    "data-geocoder-populate-country_code" => "#fiscal-country",
+                    "data-geocoder-populate-latitude" => "#fiscal-latitude",
+                    "data-geocoder-populate-longitude" => "#fiscal-longitude",
+                    'placeholder' => 'invest-address-address-field'
+                ]
+            ])
+            ->add('location', TextType::class, [
+                'label' => 'invest-address-location-field',
+                'attr' => [
+                    'id' => 'fiscal-address',
+                    'class' => 'form-control geo-autocomplete',
+                    "data-geocoder-populate-address" => "#fiscal-address",
+                    "data-geocoder-populate-city" => "#fiscal-location",
+                    "data-geocoder-populate-region" => "#fiscal-region",
+                    "data-geocoder-populate-zipcode" => "#fiscal-zipcode",
+                    "data-geocoder-populate-country_code" => "#fiscal-country",
+                    "data-geocoder-populate-latitude" => "#fiscal-latitude",
+                    "data-geocoder-populate-longitude" => "#fiscal-longitude",
+                    'placeholder' => 'invest-address-address-field'
+                ],
+                'required' => true
+            ])
+            ->add('zipcode', TextType::class, [
+                'label' => 'invest-address-zipcode-field',
+                'attr' => [
+                    'id' => 'fiscal-zipcode',
+                    'placeholder' => 'invest-address-zipcode-field'
+                ],
+                'required' => true
+            ])
+            ->add('region', TextType::class, [
+                'label' => 'invest-address-country-field',
+                'required' => true
+
+            ])
+            ->add('country', ChoiceType::class, [
+                'label' => 'invest-address-country-field',
+                'choices' => array_flip(Lang::listCountries()),
+                'attr' => [
+                    'id' => 'fiscal-country',
+                    'placeholder' => 'invest-address-country-field',
+                ],
+                'data' => strtoupper($model->country)
+            ])
+            ->add('fiscal-latitude', HiddenType::class, [
+                'data' => $model->latitude,
+                'attr' => [
+                    'id' => 'fiscal-latitude'
+                ]
+            ])
+            ->add('fiscal-longitude', HiddenType::class, [
+                'data' => $model->longitude,
+                'attr' => [
+                    'id' => 'fiscal-longitude'
+                ]
+            ])
+        ;
+
+        return $this;
+    }
+
+    public function save(FormInterface $form = null, $force_save = false)
+    {
+        $data = $form->getData();
+        $model = $this->getModel();
+        $model->rebuildData($data, array_keys($form->all()));
+    }
+
+}

--- a/src/Goteo/Library/Forms/Model/InvestAddressForm.php
+++ b/src/Goteo/Library/Forms/Model/InvestAddressForm.php
@@ -27,14 +27,15 @@ class InvestAddressForm extends AbstractFormProcessor implements FormProcessorIn
                 'choices' => [
                     Text::get('donor-legal-entities-natural-person') => 'natural_person',
                     Text::get('donor-legal-entities-legal-person') => 'legal_person'
-                ]
+                ],
             ])
             ->add('name', TextType::class, [
                 'label' => 'personal-field-donor_name',
                 'attr' => [
                     'placeholder' => 'personal-field-donor_name'
                 ],
-                'required' => true
+                'required' => true,
+                'data' => $model->getName()
             ])
             ->add('surname', TextType::class, [
                 'label' => 'personal-field-donor_surname',
@@ -133,7 +134,7 @@ class InvestAddressForm extends AbstractFormProcessor implements FormProcessorIn
                     'id' => 'fiscal-country',
                     'placeholder' => 'invest-address-country-field',
                 ],
-                'data' => strtoupper($model->country)
+                'data' => strtoupper($model->getCountry())
             ])
             ->add('fiscal-latitude', HiddenType::class, [
                 'data' => $model->latitude,
@@ -157,6 +158,8 @@ class InvestAddressForm extends AbstractFormProcessor implements FormProcessorIn
         $data = $form->getData();
         $model = $this->getModel();
         $model->rebuildData($data, array_keys($form->all()));
+
+        $model->save();
     }
 
 }

--- a/src/Goteo/Model/Invest/InvestAddress.php
+++ b/src/Goteo/Model/Invest/InvestAddress.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Goteo\Model\Invest;
+
+use Goteo\Application\Exception\ModelNotFoundException;
+use Goteo\Core\Model;
+
+class InvestAddress extends Model
+{
+    protected $Table = 'invest_address';
+    protected static $Table_static = 'invest_address';
+
+    private int $invest;
+    private string $user;
+    private ?string $address = null;
+    private ?string $zipcode = null;
+    private ?string $location = null;
+    private ?string $country = null;
+    private ?string $name = null;
+    private ?string $nif = null;
+    private ?string $namedest = null;
+    private ?string $emaildest = null;
+    private ?bool $regalo = null;
+    private ?string $message = null;
+
+    public function getInvest(): int
+    {
+        return $this->invest;
+    }
+
+    public function setInvest(int $invest): InvestAddress
+    {
+        $this->invest = $invest;
+        return $this;
+    }
+
+    public function getUser(): string
+    {
+        return $this->user;
+    }
+
+    public function setUser(string $user): InvestAddress
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getAddress(): ?string
+    {
+        return $this->address;
+    }
+
+    public function setAddress(?string $address): InvestAddress
+    {
+        $this->address = $address;
+        return $this;
+    }
+
+    public function getZipcode(): ?string
+    {
+        return $this->zipcode;
+    }
+
+    public function setZipcode(?string $zipcode): InvestAddress
+    {
+        $this->zipcode = $zipcode;
+        return $this;
+    }
+
+    public function getLocation(): ?string
+    {
+        return $this->location;
+    }
+
+    public function setLocation(?string $location): InvestAddress
+    {
+        $this->location = $location;
+        return $this;
+    }
+
+    public function getCountry(): ?string
+    {
+        return $this->country;
+    }
+
+    public function setCountry(?string $country): InvestAddress
+    {
+        $this->country = $country;
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): InvestAddress
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getNif(): ?string
+    {
+        return $this->nif;
+    }
+
+    public function setNif(?string $nif): InvestAddress
+    {
+        $this->nif = $nif;
+        return $this;
+    }
+
+    public function getNamedest(): ?string
+    {
+        return $this->namedest;
+    }
+
+    public function setNamedest(?string $namedest): InvestAddress
+    {
+        $this->namedest = $namedest;
+        return $this;
+    }
+
+    public function getEmaildest(): ?string
+    {
+        return $this->emaildest;
+    }
+
+    public function setEmaildest(?string $emaildest): InvestAddress
+    {
+        $this->emaildest = $emaildest;
+        return $this;
+    }
+
+    public function getRegalo(): ?bool
+    {
+        return $this->regalo;
+    }
+
+    public function setRegalo(?bool $regalo): InvestAddress
+    {
+        $this->regalo = $regalo;
+        return $this;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(?string $message): InvestAddress
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    public function save(&$errors = array())
+    {
+        $fields = [
+            'invest' => ':invest',
+            'user' => ':user',
+            'address' => ':address',
+            'zipcode' => ':zipcode',
+            'location' => ':location',
+            'country' => ':country',
+            'name' => ':name',
+            'nif' => ':nif',
+            'namedest' => ':namedest',
+            'emaildest' => ':emaildest',
+            'regalo' => ':regalo',
+            'message' => ':message'
+        ];
+
+        $values = [
+            'invest' => $this->invest,
+            'user' => $this->user,
+            'address' => $this->address,
+            'zipcode' => $this->zipcode,
+            'location' => $this->location,
+            'country' => $this->country,
+            'name' => $this->name,
+            'nif' => $this->nif,
+            'namedest' => $this->namedest,
+            'emaildest' => $this->emaildest,
+            'regalo' => $this->regalo,
+            'message' => $this->message
+        ];
+
+        $sql = "REPLACE INTO `$this->table` (" . implode(',', array_keys($fields) ) . ") VALUES (" . implode(',', array_values($fields)) . ")";
+        try {
+            $this->query($sql, $values);
+        } catch (PDOException $exception) {
+            $errors[] = $exception->getMessage();
+        }
+
+        return $this;
+    }
+
+    public function validate(&$errors = array()): bool
+    {
+        return (bool) $this->invest;
+    }
+
+    /**
+     * @throws ModelNotFoundException
+     */
+    static function getByInvest(int $invest): InvestAddress
+    {
+        $sql = "SELECT invest_address.*
+                FROM invest_address
+                WHERE invest_address.invest = ?";
+
+        $investAddress = self::query($sql, [$invest]);
+        if (!$investAddress instanceOf InvestAddress)
+            throw new ModelNotFoundException("Not found Invest Address with invest[$invest]");
+
+        return $investAddress;
+    }
+}


### PR DESCRIPTION
This PR creates a new model for the invest address table and the symfony form needed to handle all the data that the user has to give.

The problem with this PR is that it's really soft spot in all the donation process of the platform.

The page were this data is added has the data of two different models. First, all the data related to the donor fiscal information, and then the information for the invest address. 

We should create two forms but handle them as one, how can we do that? Should be create another step in the process? Will it the too long for the user?

Also, at first, i had created the model as a new Entity, but the code in the Controller to handle form creations is binded to the Model class.

Also, this views are used in the core application and also inside private zones of goteo. I would like to have a discussion in this topic prior to advance with this development.