### PR TITLE
Update AuthController.php

### DIFF
--- a/src/Goteo/Controller/AuthController.php
+++ b/src/Goteo/Controller/AuthController.php
@@ -156,15 +156,15 @@ class AuthController extends Controller {
 
             $user->save($errors);
 
-            // Set user newsletter notifications preferences
-            $newsletter_no_active=isset($vars['newsletter_accept']) ? 0 : 1;
-
-            User::setPreferences($user, ['mailing' => $newsletter_no_active], $errors);
-
             if (empty($errors)) {
                 Message::info(Text::get('user-register-success'));
                 // no confirmation..., direct login
                 $user = User::get($user->id);
+                
+                // Set user newsletter notifications preferences
+                $newsletter_no_active=isset($vars['newsletter_accept']) ? 0 : 1;
+                User::setPreferences($user, ['mailing' => $newsletter_no_active], $errors);
+                
                 Session::setUser($user);
                 //Redirect
                  //Everything ok, redirecting


### PR DESCRIPTION
User preferences are set once user is created.

This solves a bug that happens when you fail at user registration.

You got this error message:

FALLO al gestionar las preferencias de notificación SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`goteodb_PRO`.`user_prefer`, CONSTRAINT `user_prefer_ibfk_1` FOREIGN KEY (`user`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE)