### PR TITLE
Fix styles for side-widget in project partials

### DIFF
--- a/Resources/templates/responsive/project/partials/side.php
+++ b/Resources/templates/responsive/project/partials/side.php
@@ -69,20 +69,21 @@
     </ul>
 
     <ul class="collaborations list-unstyled">
-        <!-- List of collaborations -->
         <?php foreach ($project->supports as $support): ?>
-            <li id="<?= $support->id ?>" class="side-widget">
-                <h3 class="text-bold">
-                    <?= $support->support ?>
-                </h3>
-                <p class="spacer-20">
-                    <?= substr($support->description,0,150) ?>
-                </p>
-                <div class="spacer-5">
-                    <a class="btn btn-block btn-green" href="<?= '/project/'.$project->id.'/participate#msg-'.$support->thread ?>">
-                        <?= $this->text('regular-collaborate') ?>
-                    </a>
-                </div>
+            <li class="side-widget">
+                <article id="support-<?= $support->id ?>" class="support-widget">
+                    <h4 class="text-bold">
+                        <?= $support->support ?>
+                    </h4>
+                    <p class="spacer-20" title="<?= $support->description ?>">
+                        <?= substr($support->description,0,150) ?>
+                    </p>
+                    <div class="spacer-5">
+                        <a class="btn btn-block btn-green" href="<?= '/project/'.$project->id.'/participate#msg-'.$support->thread ?>">
+                            <?= $this->text('regular-collaborate') ?>
+                        </a>
+                    </div>
+                </article>
             </li>
         <?php endforeach ?>
     </ul>

--- a/public/assets/sass/project.scss
+++ b/public/assets/sass/project.scss
@@ -676,40 +676,7 @@ div {
     }
   }
   &.widget.rewards {}
-  &.side-widget {
-    background-color: $background-white;
-    padding: 5%;
-    border-radius: 10px;
-    margin-bottom: 5px;
-    font-size: 13px;
-    word-wrap: break-word;
-    // make all images resonsive here
-    img {
-      display: block;
-      max-width: 100%;
-      height: auto;
-      margin: 4px 0;
-    }
-
-    h3 {
-      font-size: 16px;
-    }
-
-    .amount {
-      font-size: 16px;
-      font-weight: bold;
-    }
-    .investors {
-      text-transform: uppercase;
-      color: #C054BA;
-      font-weight: bold;
-      padding: 15px 0;
-      div.left {
-        font-weight: normal;
-      }
-    }
-  }
-  &.collaborations {
+  .collaborations {
     margin-top: 15px;
   }
   &.social-commitment {
@@ -736,6 +703,41 @@ ul.collaboration-list {
     color: $color-dark !important;
     font-weight: bold;
     text-transform: uppercase;
+  }
+}
+
+
+li.side-widget {
+  background-color: $background-white;
+  padding: 5%;
+  border-radius: 10px;
+  margin-bottom: 5px;
+  font-size: 13px;
+  word-wrap: break-word;
+  // make all images resonsive here
+  img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: 4px 0;
+  }
+
+  h3 {
+    font-size: 16px;
+  }
+
+  .amount {
+    font-size: 16px;
+    font-weight: bold;
+  }
+  .investors {
+    text-transform: uppercase;
+    color: #C054BA;
+    font-weight: bold;
+    padding: 15px 0;
+    div.left {
+      font-weight: normal;
+    }
   }
 }
 


### PR DESCRIPTION
The social rewards list has lost it's styles after we implemented some improvements in accessibility.

![imatge](https://github.com/GoteoFoundation/goteo/assets/41389482/1840cdb9-9d1f-41c7-8662-64c92c1b81eb)

This PR tries to fix this applying the styles to the new html tags chosen for the list of social rewards. Previously the list was a set of divs, and every item was just another set of divs with the inner information. Currently the list is created with the ul and li tags, and inside every item we have an article and a header for the title.

![imatge](https://github.com/GoteoFoundation/goteo/assets/41389482/e852a702-7eea-4b17-a502-cbeed8617ed6)



