### PR TITLE
Private-Zones Plugin - Check private zones based on uri and not only on path

### DIFF
--- a/extend/private-zones/src/Goteo/Application/EventListener/BasicAuthListener.php
+++ b/extend/private-zones/src/Goteo/Application/EventListener/BasicAuthListener.php
@@ -22,7 +22,7 @@ class BasicAuthListener extends AbstractListener {
         }
 
         $request = $event->getRequest();
-        $uri     = $request->getPathInfo();
+        $uri     = $request->getUri();
 
         $public = Config::get('plugins.private-zones.public');
         if(is_array($public)) {
@@ -40,7 +40,8 @@ class BasicAuthListener extends AbstractListener {
             foreach($private as $user => $ops) {
                 if($ops['password'] && $ops['paths'] && is_array($ops['paths'])) {
                     foreach($ops['paths'] as $path) {
-                        if(strpos($uri, $path) === 0) {
+                        $position = strpos($uri, $path);
+                        if($position || $position === 0) {
                             $users[$user] = $ops['password'];
                         }
                     }


### PR DESCRIPTION
When configuring the private zone for a new domain, it only took into consideration the path of the URL.

With this change, we want to take into account also new domains that the application could be using.

To test these changes do this:

```
    private-zones: # Creates HTTP Basic Auth in certain paths
        active: true
        private:
            usertest:
                password: userpassword
                paths:
                    - /channel/channel-id
                    - newdomain.test
```

This will result on newdomain.test having also the HTTP Auth.