### PR TITLE
Allow project owner to change project type

### DIFF
--- a/src/Goteo/Library/Forms/Model/ProjectCampaignForm.php
+++ b/src/Goteo/Library/Forms/Model/ProjectCampaignForm.php
@@ -45,15 +45,20 @@ class ProjectCampaignForm extends AbstractFormProcessor implements FormProcessor
 
         $builder = $this->getBuilder();
         $admin = Session::isAdmin();
+
+        $builder
+            ->add('type', ChoiceType::class, [
+                'label' => 'project-campaign-type-label',
+                'data' => $project->type ?? $project->getConfig()->getType(),
+                'choices' => $this->projectTypeChoices(),
+                'required' => false,
+                'attr' => [
+                    'pre-help' => Text::get('project-campaign-type-prehelp'),
+                ]
+        ]);
+
         if ($admin) {
             $builder
-                ->add('type', ChoiceType::class, [
-                    'label' => 'project-campaign-type-label',
-                    'row_class' => 'extra',
-                    'data' => $project->type ?? $project->getConfig()->getType(),
-                    'choices' => $this->projectTypeChoices(),
-                    'required' => false
-                ])
                 ->add('impact_calculator', BooleanType::class, [
                     'label' => 'project-campaign-impact-calculator',
                     'row_class' => 'extra',
@@ -128,7 +133,8 @@ class ProjectCampaignForm extends AbstractFormProcessor implements FormProcessor
         ];
     }
 
-    public function save(FormInterface $form = null, $force_save = false) {
+    public function save(FormInterface $form = null, $force_save = false): ProjectCampaignForm
+    {
 
         if(!$form) $form = $this->getBuilder()->getForm();
         if(!$form->isValid() && !$force_save) throw new FormModelException(Text::get('form-has-errors'));
@@ -142,7 +148,6 @@ class ProjectCampaignForm extends AbstractFormProcessor implements FormProcessor
             throw new FormModelException(Text::get('form-sent-error', implode(', ',$errors)));
         }
 
-        $data = $form->getData();
         $account = $this->getOption('account');
         $account->rebuildData(['allowpp' => $data['allowpp']]);
 

--- a/translations/ca/project.yml
+++ b/translations/ca/project.yml
@@ -165,3 +165,4 @@ project-campaign-activate-impact-calculator: "Al activar la calculadora d'impact
 project-campaign-type-label: "Escull tipus de campanya"
 project-campaign-type-campaign: "Campanya"
 project-campaign-type-permanent: "Permanent"
+project-campaign-type-prehelp: "Aquest camp permet escollir el tipus de campanya que es vol fer. Si es vol fer un projecte per rondes s'ha d'escollir `campanya`. Si es vol fer una campanya `permanent`, s'ha d'escollir permanent."

--- a/translations/en/project.yml
+++ b/translations/en/project.yml
@@ -162,3 +162,4 @@ project-campaign-activate-impact-calculator: "By activating the impact calculato
 project-campaign-type-label: "Choose type of Campaign"
 project-campaign-type-campaign: "Campaign"
 project-campaign-type-permanent: "Permanent"
+project-campaign-type-prehelp: "This field allows you to choose the type of campaign you want to do. If you want to make a project for rounds you have to choose `campaign`. If you want to make a `permanent` campaign, you have to choose permanent."

--- a/translations/es/project.yml
+++ b/translations/es/project.yml
@@ -184,3 +184,4 @@ project-campaign-activate-impact-calculator: "Al activar la calculadora de impac
 project-campaign-type-label: "Escoge tipo de campaña"
 project-campaign-type-campaign: "Campaña"
 project-campaign-type-permanent: "Permanente"
+project-campaign-type-prehelp: "Este campo permite escoger el tipo de campaña que se quiere hacer. Si se quiere hacer un proyecto por rondas se tiene que escoger `campaña`, si se quiere hacer una campaña permanente se debe escoer `permanente`."

--- a/translations/es/project.yml
+++ b/translations/es/project.yml
@@ -184,4 +184,4 @@ project-campaign-activate-impact-calculator: "Al activar la calculadora de impac
 project-campaign-type-label: "Escoge tipo de campaña"
 project-campaign-type-campaign: "Campaña"
 project-campaign-type-permanent: "Permanente"
-project-campaign-type-prehelp: "Este campo permite escoger el tipo de campaña que se quiere hacer. Si se quiere hacer un proyecto por rondas se tiene que escoger `campaña`, si se quiere hacer una campaña permanente se debe escoer `permanente`."
+project-campaign-type-prehelp: "Este campo permite escoger el tipo de campaña que se quiere hacer. Si se quiere hacer un proyecto por rondas se tiene que escoger `campaña`, si se quiere hacer una campaña permanente se debe escoger `permanente`."


### PR DESCRIPTION
#### :tophat: What? Why?

Allow project owner to change the type of the project.

The two types of project that the owner can choose are:
- Campaign
- Permanent

Campaign is the classical type of project held in Goteo. It works using rounds and is an All-or-nothing model. The permanent campaign allows the project to have a project that does not end.

This decision was made by the admins of the platform, but with this PR the owners can decide this for themselves.

#### :pushpin: Related Issues

This PR is inside the the Recurring campaigns project.

#### Testing
*Describe the best way to test or validate your PR.*

Enter in the dashboard of a Project that has a state previous of 'In Campaign (3)'.  Enter in the 'Campaign' module. Make sure that it can be modified by the project owner and as an admin.

Try the same with a project that has been published or already financed. Check that the whole module is not accessible by the project owner.

 ### :camera: Screenshots

![imatge](https://github.com/GoteoFoundation/goteo/assets/41389482/0883c12f-9acb-4787-9312-6c9573a94497)


:hearts: Thank you!
