### PR TITLE
Allow to filter investments by contract number

### DIFF
--- a/Resources/templates/default/admin/accounts/list.php
+++ b/Resources/templates/default/admin/accounts/list.php
@@ -91,6 +91,11 @@ $coord = [];
             <input type="text" id ="id-filter" name="id" value ="<?= $filters['id']?>" />
         </div>
 
+        <div style="float:left;margin:5px;">
+            <label for="contract-filter">N. de contrato:</label><br />
+            <input type="text" id ="contract-filter" name="contract" value ="<?= $filters['contract']?>" />
+        </div>
+
         <br clear="both" />
 
         <div style="float:left;margin:5px;">

--- a/src/Goteo/Controller/Admin/AccountsSubController.php
+++ b/src/Goteo/Controller/Admin/AccountsSubController.php
@@ -67,6 +67,7 @@ class AccountsSubController extends AbstractSubController {
       'procStatus' => 'all',
       'amount' => '',
       'maxamount' => '',
+      'contract' => ''
     );
 
     /**

--- a/src/Goteo/Model/Invest.php
+++ b/src/Goteo/Model/Invest.php
@@ -513,6 +513,10 @@ class Invest extends Model {
             }
         }
 
+        if (!empty($filters['contract'])) {
+            $sqlFilter[] = "contract.number = :contract";
+            $values[':contract'] = $filters['contract'];
+        }
         if (!empty($filters['date_from'])) {
             $sqlFilter[] = "invest.invested >= :date_from";
             $values[':date_from'] = $filters['date_from'];
@@ -603,6 +607,8 @@ class Invest extends Model {
                     ON invest.admin = user.id
                 LEFT JOIN invest_reward
                     ON invest_reward.invest = invest.id
+                LEFT JOIN `contract`
+                    ON contract.project = invest.project
                 $sqlFilter";
 
                 // echo sqldbg($sql, $values)."\n";
@@ -633,6 +639,8 @@ class Invest extends Model {
                     ON invest.admin = user.id
                 LEFT JOIN invest_reward
                     ON invest_reward.invest = invest.id
+                LEFT JOIN `contract`
+                    ON contract.project = invest.project
                 $sqlFilter
                 " . ($order ? "ORDER BY $order" : '') ."
                 LIMIT $offset, $limit


### PR DESCRIPTION
#### :tophat: What? Why?
Admins have trouble looking up investments by project but contract numbers are easier to identify and remember, this PR allows them to quickly sort investments by the contract number.

#### Testing
Navigate to your local admin panel and in the "accounts" page, try the new filter with any existing contract on your database. Lookup is by exact matches.

### :camera: Screenshots
![Contract number filter at admin accounts filters](https://github.com/GoteoFoundation/goteo/assets/61125897/61b73e24-c70a-48b0-8463-b655973d45e7)

:hearts: Thank you!