### PR TITLE
Minimalistic channel call footer

### DIFF
--- a/Resources/templates/responsive/channel/call/partials/footer.php
+++ b/Resources/templates/responsive/channel/call/partials/footer.php
@@ -1,66 +1,9 @@
-<?php $channel=$this->channel; ?>
-
-<footer id="footer" class="footer">
-    <div class="container-fluid">
-      <div class="container">
-        <div class="row header">
-          <div class="pull-left">
-            <a href="<?= '/channel/'.$this->channel->id ?> ">
-              <img src="<?= $channel->logo_footer ? $channel->logo_footer->getlink(0,50) : '' ?>" height="50">
-            </a>
-          </div>
-          <div class="pull-right">
-            <span><?= $this->text('call-header-powered-by') ?></span>
-            <a href="<?= $this->get_config('url.main') ?>">
-              <img src="<?= '/assets/img/goteo-blue-green.svg' ?>" >
-            </a>
-          </div>
-        </div>
-        <div class="row spacer-20">
-          <div class="col-md-6 col-sm-8">
-            <div class="spacer-20">
-              <?= $this->t('channel-call-footer-information') ?>
-            </div>
-            <div class="row">
-              <div class="col-md-6 col-sm-6 col-xs-6">
-                <ul>
-                  <li><a href="/about" target="_blank"><?= $this->t('channel-call-footer-about') ?> </a></li>
-                  <li><a href="https://stats.goteo.org" target="_blank"><?= $this->t('channel-call-footer-stats') ?> </a></li>
-                  <li><a href="/legal/terms" target="_blank"><?= $this->t('channel-call-footer-conditions') ?> </a></li>
-                  <li><a href="/legal/privacy" target="_blank"><?= $this->t('channel-call-footer-privacy') ?> </a></li>
-                </ul>
-              </div>
-              <div class="col-md-6 col-sm-6 col-xs-6">
-                <ul>
-                  <li><a href="/about/librejs" target="_blank"><?= $this->t('channel-call-footer-licenses') ?> </a></li>
-                  <li><a href="/faq" target="_blank"><?= $this->t('channel-call-footer-faq') ?> </a></li>
-                  <li><a href="/contact" target="_blank"><?= $this->t('channel-call-footer-contact') ?> </a></li>
-                </ul>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-sm-4">
-            <div class="spacer-20">
-              <?= $this->t('channel-call-footer-social-networks') ?>
-            </div>
-            <div class="row">
-              <div class="col-md-6 col-sm-12 col-xs-6">
-                <ul>
-                  <li><a href="<?=$this->text('social-account-twitter') ?>" target="_blank"><span class="icon icon-channel-twitter"></span> <?= $this->t('channel-call-footer-twitter') ?> </a></li>
-                  <li><a href="<?=$this->text('social-account-facebook') ?>" target="_blank"><span class="icon icon-channel-fb"></span> <?= $this->t('channel-call-footer-facebook') ?> </a></li>
-                  <li><a href="<?=$this->text('social-account-instagram') ?>" target="_blank"><span class="icon icon-channel-instagram"></span> <?= $this->t('channel-call-footer-instagram') ?> </a></li>
-                </ul>
-              </div>
-              <div class="col-md-6 col-sm-12 col-xs-6">
-              <ul>
-                  <li><a href="<?=$this->text('social-account-telegram') ?>" target="_blank"><span class="icon icon-channel-telegram"></span> <?= $this->t('channel-call-footer-telegram') ?> </a></li>
-                  <li><a href="<?=$this->text('social-account-github') ?>" target="_blank"><span class="icon icon-channel-github"></span> <?= $this->t('channel-call-footer-github') ?> </a></li>
-                  <li><a href="/newsletter" target="_blank"><span class="icon icon-channel-mail"></span> <?= $this->t('channel-call-footer-newsletter') ?> </a></li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-</footer>
+<?php
+$channel=$this->channel;
+$section = $channel->getSections('footer');
+if ($section):
+?>
+    <?= $this->insert('channel/call/partials/minimal_footer'); ?>
+<?php else: ?>
+    <?= $this->insert('channel/call/partials/full_footer'); ?>
+<?php endif; ?>

--- a/Resources/templates/responsive/channel/call/partials/full_footer.php
+++ b/Resources/templates/responsive/channel/call/partials/full_footer.php
@@ -1,0 +1,66 @@
+<?php $channel=$this->channel; ?>
+
+<footer id="footer" class="footer">
+    <div class="container-fluid">
+      <div class="container">
+        <div class="row header">
+          <div class="pull-left">
+            <a href="<?= '/channel/'.$this->channel->id ?> ">
+              <img src="<?= $channel->logo_footer ? $channel->logo_footer->getlink(0,50) : '' ?>" height="50">
+            </a>
+          </div>
+          <div class="pull-right">
+            <span><?= $this->text('call-header-powered-by') ?></span>
+            <a href="<?= $this->get_config('url.main') ?>">
+              <img src="<?= '/assets/img/goteo-blue-green.svg' ?>" >
+            </a>
+          </div>
+        </div>
+        <div class="row spacer-20">
+          <div class="col-md-6 col-sm-8">
+            <div class="spacer-20">
+              <?= $this->t('channel-call-footer-information') ?>
+            </div>
+            <div class="row">
+              <div class="col-md-6 col-sm-6 col-xs-6">
+                <ul>
+                  <li><a href="/about" target="_blank"><?= $this->t('channel-call-footer-about') ?> </a></li>
+                  <li><a href="https://stats.goteo.org" target="_blank"><?= $this->t('channel-call-footer-stats') ?> </a></li>
+                  <li><a href="/legal/terms" target="_blank"><?= $this->t('channel-call-footer-conditions') ?> </a></li>
+                  <li><a href="/legal/privacy" target="_blank"><?= $this->t('channel-call-footer-privacy') ?> </a></li>
+                </ul>
+              </div>
+              <div class="col-md-6 col-sm-6 col-xs-6">
+                <ul>
+                  <li><a href="/about/librejs" target="_blank"><?= $this->t('channel-call-footer-licenses') ?> </a></li>
+                  <li><a href="/faq" target="_blank"><?= $this->t('channel-call-footer-faq') ?> </a></li>
+                  <li><a href="/contact" target="_blank"><?= $this->t('channel-call-footer-contact') ?> </a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-6 col-sm-4">
+            <div class="spacer-20">
+              <?= $this->t('channel-call-footer-social-networks') ?>
+            </div>
+            <div class="row">
+              <div class="col-md-6 col-sm-12 col-xs-6">
+                <ul>
+                  <li><a href="<?=$this->text('social-account-twitter') ?>" target="_blank"><span class="icon icon-channel-twitter"></span> <?= $this->t('channel-call-footer-twitter') ?> </a></li>
+                  <li><a href="<?=$this->text('social-account-facebook') ?>" target="_blank"><span class="icon icon-channel-fb"></span> <?= $this->t('channel-call-footer-facebook') ?> </a></li>
+                  <li><a href="<?=$this->text('social-account-instagram') ?>" target="_blank"><span class="icon icon-channel-instagram"></span> <?= $this->t('channel-call-footer-instagram') ?> </a></li>
+                </ul>
+              </div>
+              <div class="col-md-6 col-sm-12 col-xs-6">
+              <ul>
+                  <li><a href="<?=$this->text('social-account-telegram') ?>" target="_blank"><span class="icon icon-channel-telegram"></span> <?= $this->t('channel-call-footer-telegram') ?> </a></li>
+                  <li><a href="<?=$this->text('social-account-github') ?>" target="_blank"><span class="icon icon-channel-github"></span> <?= $this->t('channel-call-footer-github') ?> </a></li>
+                  <li><a href="/newsletter" target="_blank"><span class="icon icon-channel-mail"></span> <?= $this->t('channel-call-footer-newsletter') ?> </a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+</footer>

--- a/Resources/templates/responsive/channel/call/partials/minimal_footer.php
+++ b/Resources/templates/responsive/channel/call/partials/minimal_footer.php
@@ -1,0 +1,35 @@
+<?php $channel=$this->channel; ?>
+
+<footer id="footer" class="footer minimal-footer">
+    <div class="container-fluid">
+        <div class="container">
+            <div class="row header">
+                <div class="pull-left">
+                    <a href="<?= '/channel/'.$this->channel->id ?> ">
+                        <img src="<?= $channel->logo_footer ? $channel->logo_footer->getlink(0,50) : '' ?>" height="50">
+                    </a>
+                </div>
+                <div class="pull-right">
+                    <span><?= $this->text('call-header-powered-by') ?></span>
+                    <a href="<?= $this->get_config('url.main') ?>">
+                        <img src="<?= '/assets/img/goteo-blue-green.svg' ?>" >
+                    </a>
+                </div>
+            </div>
+            <div class="row spacer-20">
+                <div class="spacer-20">
+                    <?= $this->t('channel-call-footer-information') ?>
+                <div class="row">
+                    <ul>
+                        <li class="col-md-2 col-sm-4 col-xs-4"><a href="/about" target="_blank"><?= $this->t('channel-call-footer-about') ?> </a></li>
+                        <li class="col-md-2 col-sm-4 col-xs-4"><a href="/legal/terms" target="_blank"><?= $this->t('channel-call-footer-conditions') ?> </a></li>
+                        <li class="col-md-2 col-sm-4 col-xs-4"><a href="/legal/privacy" target="_blank"><?= $this->t('channel-call-footer-privacy') ?> </a></li>
+                        <li class="col-md-2 col-sm-4 col-xs-4"><a href="/about/librejs" target="_blank"><?= $this->t('channel-call-footer-licenses') ?> </a></li>
+                        <li class="col-md-2 col-sm-4 col-xs-4"><a href="/channel/<?= $channel->id ?>/faq" target="_blank"><?= $this->t('channel-call-footer-faq') ?> </a></li>
+                        <li class="col-md-2 col-sm-4 col-xs-4"><a href="/contact" target="_blank"><?= $this->t('channel-call-footer-contact') ?> </a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/public/assets/sass/layouts/_channel_call.scss
+++ b/public/assets/sass/layouts/_channel_call.scss
@@ -1575,6 +1575,18 @@ footer {
 			}
 		}
 	}
+
+  &.minimal-footer {
+    ul li {
+      border-bottom: unset !important;
+      &::after {
+        content: '';
+        border-bottom: 1px solid $color-new-dark-blue;
+        width: 90%;
+        display: block;
+      }
+    }
+  }
 }
 
 // Tablets customization

--- a/src/Goteo/Model/Node/NodeSections.php
+++ b/src/Goteo/Model/Node/NodeSections.php
@@ -6,12 +6,13 @@
 
  namespace Goteo\Model\Node;
 
+ use Goteo\Core\Model;
  use Goteo\Model\Image;
  use Goteo\Application\Lang;
  use Goteo\Application\Config;
  use Goteo\Library\Text;
 
- class NodeSections extends \Goteo\Core\Model {
+ class NodeSections extends Model {
 
   protected $Table = 'node_sections';
   protected static $Table_static = 'node_sections';
@@ -27,10 +28,11 @@
   const SECTION_TEAM            = 'team';
   const SECTION_SPONSORS        = 'sponsors';
   const SECTION_DATA_SETS       = 'data_sets';
+  const SECTION_FOOTER          = 'footer';
 
 
 
-  static $SECTIONS = [
+  static array $SECTIONS = [
       self::SECTION_MAP,
       self::SECTION_RESOURCES,
       self::SECTION_CALL_TO_ACTION,
@@ -41,7 +43,8 @@
       self::SECTION_WORKSHOPS,
       self::SECTION_TEAM,
       self::SECTION_SPONSORS,
-      self::SECTION_DATA_SETS
+      self::SECTION_DATA_SETS,
+      self::SECTION_FOOTER
   ];
 
   public
@@ -54,7 +57,8 @@
       $main_button,
       $order = 1;
 
-    public static function getLangFields() {
+    public static function getLangFields(): array
+    {
         return ['main_title', 'main_description', 'main_button'];
     }
 
@@ -209,7 +213,8 @@
     }
 
 
-    public static function getSectionNames() {
+    public static function getSectionNames(): array
+    {
       return [
         self::SECTION_MAP => Text::get('admin-channelsection-map'),
         self::SECTION_RESOURCES => Text::get('admin-channelsection-resource'),
@@ -220,7 +225,9 @@
         self::SECTION_STORIES => Text::get('admin-channelsection-stories'),
         self::SECTION_WORKSHOPS => Text::get('admin-channelsection-workshops'),
         self::SECTION_TEAM => Text::get('admin-channelsection-team'),
-        self::SECTION_SPONSORS => Text::get('admin-channelsection-sponsors')
+        self::SECTION_SPONSORS => Text::get('admin-channelsection-sponsors'),
+        self::SECTION_DATA_SETS => Text::get('admin-channelsection-data_sets'),
+        self::SECTION_FOOTER => Text::get('admin-channelsection-footer')
       ];
     }
  }

--- a/translations/ca/admin.yml
+++ b/translations/ca/admin.yml
@@ -121,6 +121,7 @@ admin-channelsection-workshops: 'Tallers'
 admin-channelsection-team: 'Equip'
 admin-channelsection-sponsors: 'Sponsors'
 admin-channelsection-data_sets: "Data sets"
+admin-channelsection-footer: "Footer"
 admin-channelsection-button: 'Botó'
 admin-channelsection-create: 'Crear'
 admin-channelsection-add: 'Afegir una secció'

--- a/translations/en/admin.yml
+++ b/translations/en/admin.yml
@@ -148,6 +148,7 @@ admin-channelsection-workshops: 'Workshops'
 admin-channelsection-team: 'Team'
 admin-channelsection-sponsors: 'Sponsors'
 admin-channelsection-data_sets: "Data sets"
+admin-channelsection-footer: "Footer"
 admin-channelsection-button: 'Button'
 admin-channelsection-create: 'Create'
 admin-channelsection-add: 'Add a Section'

--- a/translations/es/admin.yml
+++ b/translations/es/admin.yml
@@ -150,6 +150,7 @@ admin-channelsection-workshops: 'Talleres'
 admin-channelsection-team: 'Equipo'
 admin-channelsection-sponsors: 'Sponsors'
 admin-channelsection-data_sets: "Data sets"
+admin-channelsection-footer: "Footer"
 admin-channelsection-button: 'Botón'
 admin-channelsection-create: 'Crear'
 admin-channelsection-add: 'Añadir una sección'


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

Create a minimalistic footer for a channel call without so much information about the platform itlself. Since we can host channels with their own domain, the full footer can give too much information that can be misleading. 

This footer only has the necessary details for the user.

#### Testing
*Describe the best way to test or validate your PR.*

Create a new node section of type footer for the channel of type call that you want. Then go check the new footer inside the channel.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

![imatge](https://github.com/GoteoFoundation/goteo/assets/41389482/f450ab5a-ea4f-490d-88a9-50a13e14e2eb)

:hearts: Thank you!
