### PR TITLE
Fix after stripe checkout redirection query param issue

### DIFF
--- a/src/Goteo/Payment/Method/StripeSubscriptionPaymentMethod.php
+++ b/src/Goteo/Payment/Method/StripeSubscriptionPaymentMethod.php
@@ -86,7 +86,7 @@ class StripeSubscriptionPaymentMethod extends AbstractPaymentMethod
         /** @var SubscriptionGateway */
         $gateway = $this->getGateway();
 
-        return $gateway->completePurchase(['success' => true]);
+        return $gateway->completePurchase();
     }
 
     public function refundable(): bool

--- a/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
+++ b/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
@@ -75,7 +75,9 @@ class SubscriptionRequest extends AbstractRequest
 
     public function completePurchase(array $options = [])
     {
-        $session = $this->stripe->checkout->sessions->retrieve($_REQUEST['session_id']);
+        // Dirty sanitization because something is double concatenating the ?session_id query param
+        $sessionId = explode('?', $_REQUEST['session_id'])[0];
+        $session = $this->stripe->checkout->sessions->retrieve($sessionId);
 
         $this->stripe->subscriptions->update(
             $session->subscription, [


### PR DESCRIPTION
#### :tophat: What? Why?
Fix issue with the Stripe Checkout redirection to `?success_url` in prod. 
