### PR TITLE
Redirect to a second checkout on subscriptions with platform tip

### DIFF
--- a/src/Goteo/Controller/InvestController.php
+++ b/src/Goteo/Controller/InvestController.php
@@ -31,6 +31,7 @@ use Goteo\Model\User;
 use Goteo\Payment\Payment;
 use Goteo\Util\Monolog\Processor\WebProcessor;
 use Omnipay\Common\Message\ResponseInterface;
+use Omnipay\Stripe\Subscription\Message\DonationResponse;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -523,6 +524,11 @@ class InvestController extends Controller {
             if (!$response instanceof ResponseInterface) {
                 throw new RuntimeException('This response does not implements ResponseInterface.');
             }
+
+            if ($response instanceof DonationResponse) {
+                return $this->dispatch(AppEvents::INVEST_INIT_REDIRECT, new FilterInvestRequestEvent($method, $response))->getHttpResponse();
+            }
+
             if ($response->isSuccessful()) {
                 // Goto User data fill
                 Message::info(Text::get('invest-payment-success'));

--- a/src/Goteo/Controller/StripeSubscriptionController.php
+++ b/src/Goteo/Controller/StripeSubscriptionController.php
@@ -76,7 +76,7 @@ class StripeSubscriptionController extends Controller
             $invest->save();
         }
 
-        return new JsonResponse(['data' => $invest], Response::HTTP_OK);
+        return new JsonResponse(['data' => $invests], Response::HTTP_OK);
     }
 
     private function processInvoice(string $invoiceId): JsonResponse

--- a/src/Omnipay/Stripe/Subscription/Gateway.php
+++ b/src/Omnipay/Stripe/Subscription/Gateway.php
@@ -4,6 +4,7 @@ namespace Omnipay\Stripe\Subscription;
 
 use Omnipay\Common\AbstractGateway;
 use Omnipay\Common\Http\ClientInterface;
+use Omnipay\Common\Message\ResponseInterface;
 use Omnipay\Stripe\Subscription\Message\SubscriptionRequest;
 use Omnipay\Stripe\Subscription\Message\SubscriptionResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
@@ -31,7 +32,7 @@ class Gateway extends AbstractGateway
         return new SubscriptionRequest($options);
     }
 
-    public function completePurchase($options = array()): SubscriptionResponse
+    public function completePurchase($options = array()): ResponseInterface
     {
         $request = new SubscriptionRequest($options);
 

--- a/src/Omnipay/Stripe/Subscription/Message/DonationResponse.php
+++ b/src/Omnipay/Stripe/Subscription/Message/DonationResponse.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Omnipay\Stripe\Subscription\Message;
+
+use Goteo\Application\Config;
+use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RedirectResponseInterface;
+use Omnipay\Common\Message\RequestInterface;
+use Stripe\Checkout\Session as StripeSession;
+use Stripe\StripeClient;
+
+class DonationResponse extends AbstractResponse implements RedirectResponseInterface
+{
+    private StripeClient $stripe;
+
+    private StripeSession $checkout;
+
+    public function __construct(RequestInterface $request, string $checkoutSessionId)
+    {
+        parent::__construct($request, $checkoutSessionId);
+
+        $this->stripe = new StripeClient(Config::get('payments.stripe.secretKey'));
+        $this->checkout = $this->stripe->checkout->sessions->retrieve($checkoutSessionId);
+    }
+
+    public function isSuccessful()
+    {
+        return $this->checkout->status === StripeSession::STATUS_COMPLETE;
+    }
+
+    public function isRedirect()
+    {
+        return true;
+    }
+
+    public function getRedirectUrl()
+    {
+        return $this->checkout->url;
+    }
+}

--- a/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
+++ b/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
@@ -5,8 +5,10 @@ namespace Omnipay\Stripe\Subscription\Message;
 use Goteo\Application\Config;
 use Goteo\Library\Text;
 use Goteo\Model\Invest;
+use Goteo\Model\Project;
 use Goteo\Model\User;
 use Omnipay\Common\Message\AbstractRequest;
+use Stripe\Checkout\Session as CheckoutSession;
 use Stripe\Customer;
 use Stripe\Product;
 use Stripe\StripeClient;
@@ -14,6 +16,7 @@ use Stripe\StripeClient;
 class SubscriptionRequest extends AbstractRequest
 {
     private array $data;
+
     private StripeClient $stripe;
 
     public function __construct(array $data)
@@ -34,40 +37,35 @@ class SubscriptionRequest extends AbstractRequest
     {
         $user = $data['user'];
         $invest = $data['invest'];
-
         $project = $invest->getProject();
 
-        $price = $this->stripe->prices->create([
-            'unit_amount' => ($invest->amount + $invest->donate_amount) * 100,
-            'currency' => 'eur',
-            'recurring' => ['interval' => 'month'],
-            'product' => $this->getStripeProduct($invest)->id
-        ]);
+        $customer = $this->getStripeCustomer($user)->id;
+        $metadata = $this->getMetadata($project, $invest, $user);
+
+        $successUrl = sprintf('%s?session_id={CHECKOUT_SESSION_ID}', $this->getRedirectUrl(
+            'invest',
+            $project->id,
+            $invest->id,
+            'complete'
+        ));
 
         $session = $this->stripe->checkout->sessions->create([
-            'customer' => $this->getStripeCustomer($data['user'])->id,
-            'success_url' => sprintf('%s?session_id={CHECKOUT_SESSION_ID}', $this->getRedirectUrl(
-                'invest',
-                $project->id,
-                $invest->id,
-                'complete'
-            )),
-            'cancel_url' => $this->getRedirectUrl(
-                'project',
-                $project->id
-            ),
-            'mode' => 'subscription',
+            'customer' => $customer,
+            'success_url' => $successUrl,
+            'cancel_url' => $this->getRedirectUrl('project', $project->id),
+            'mode' => CheckoutSession::MODE_SUBSCRIPTION,
             'line_items' => [
                 [
-                    'price' => $price->id,
+                    'price' => $this->stripe->prices->create([
+                        'unit_amount' => $invest->amount * 100,
+                        'currency' => 'eur',
+                        'recurring' => ['interval' => 'month'],
+                        'product' => $this->getStripeProduct($invest)->id
+                    ])->id,
                     'quantity' => 1
                 ]
             ],
-            'metadata' => [
-                'project' => $project->id,
-                'reward' => $this->getInvestReward($invest, ''),
-                'user' => $user->id,
-            ]
+            'metadata' => $metadata
         ]);
 
         return new SubscriptionResponse($this, $session->id);
@@ -78,13 +76,51 @@ class SubscriptionRequest extends AbstractRequest
         // Dirty sanitization because something is double concatenating the ?session_id query param
         $sessionId = explode('?', $_REQUEST['session_id'])[0];
         $session = $this->stripe->checkout->sessions->retrieve($sessionId);
+        $metadata = $session->metadata->toArray();
 
-        $this->stripe->subscriptions->update(
-            $session->subscription, [
-            'metadata' => $session->metadata->toArray()
-        ]);
+        if ($session->subscription) {
+            $this->stripe->subscriptions->update(
+                $session->subscription,
+                [
+                    'metadata' => $metadata
+                ]
+            );
+    
+            if ($metadata['donate_amount'] < 1) {
+                return new SubscriptionResponse($this, $session->id);
+            }
 
-        return new SubscriptionResponse($this, $session->id);
+            $checkout = $this->stripe->checkout->sessions->create([
+                'customer' => $this->getStripeCustomer(User::get($metadata['user']))->id,
+                'success_url' => sprintf('%s?session_id={CHECKOUT_SESSION_ID}', $this->getRedirectUrl(
+                    'invest',
+                    $metadata['project'],
+                    $metadata['invest'],
+                    'complete'
+                )),
+                'cancel_url' => $this->getRedirectUrl('project', $metadata['project']->id),
+                'mode' => CheckoutSession::MODE_PAYMENT,
+                'line_items' => [
+                    [
+                        'price' => $this->stripe->prices->create([
+                            'unit_amount' => $metadata['donate_amount'] * 100,
+                            'currency' => 'eur',
+                            'product_data' => [
+                                'name' => Text::get('donate-meta-description')
+                            ]
+                        ])->id,
+                        'quantity' => 1
+                    ]
+                ],
+                'metadata' => $metadata
+            ]);
+    
+            return new DonationResponse($this, $checkout->id);
+        }
+
+        if ($session->payment_intent) {
+            return new SubscriptionResponse($this, $session->id);
+        }
     }
 
     private function getRedirectUrl(...$args): string
@@ -156,5 +192,16 @@ class SubscriptionRequest extends AbstractRequest
                 'description' => $productDescription
             ]);
         }
+    }
+
+    private function getMetadata(Project $project, Invest $invest, User $user): array
+    {
+        return [
+            'donate_amount' => $invest->donate_amount,
+            'project' => $project->id,
+            'invest' => $invest->id,
+            'reward' => $this->getInvestReward($invest, ''),
+            'user' => $user->id,
+        ];
     }
 }

--- a/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
+++ b/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
@@ -62,7 +62,8 @@ class SubscriptionRequest extends AbstractRequest
                         'unit_amount' => $invest->amount * 100,
                         'currency' => $project->currency,
                         'recurring' => ['interval' => 'month'],
-                        'product' => $this->getStripeProduct($invest)->id
+                        'product' => $this->getStripeProduct($invest)->id,
+                        'metadata' => $metadata
                     ])->id,
                     'quantity' => 1
                 ]


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the previously undefined behaviour of tips on subscriptions payments. See https://app.asana.com/0/1206149597772083/1206163960878458

#### Testing
If you choose to do a donation to the platform when paying with a subscription via Stripe, you'll be redirected to a second checkout (for the donation) after the first checkout (for the subscription).