### PR TITLE
Fix dashboard reward

### DIFF
--- a/Resources/templates/responsive/dashboard/project/partials/reward_item.php
+++ b/Resources/templates/responsive/dashboard/project/partials/reward_item.php
@@ -15,15 +15,17 @@ $unlimited = (int)$form["units_$id"]->vars['value'] == 0;
                 </div>
             </div>
         </div>
-        <div class="row">
-            <div class="subscribable form-group">
-                <label for="subscribable_<?= $id ?>"><?= $this->text('project-reward-subscribable') ?></label>
-                <?= $this->text('project-reward-stripe-based-subscriptions') ?>
-                <div class="input-wrap">
-                    <?= $this->form_row($form["subscribable_$id"]) ?>
+        <?php if ($this->is_admin()):?>
+            <div class="row">
+                <div class="subscribable form-group">
+                    <label for="subscribable_<?= $id ?>"><?= $this->text('project-reward-subscribable') ?></label>
+                    <?= $this->text('project-reward-stripe-based-subscriptions') ?>
+                    <div class="input-wrap">
+                        <?= $this->form_row($form["subscribable_$id"]) ?>
+                    </div>
                 </div>
             </div>
-        </div>
+        <?php endif; ?>
         <?= $this->form_row($form["reward_$id"]) ?>
         <?= $this->form_row($form["description_$id"]) ?>
         <div class="remove"><?= $this->form_row($form["remove_$id"], [],  true) ?></div>


### PR DESCRIPTION
#### :tophat: What? Why?
The dashboard of rewards is broken if the user is not admin.

#### Testing
Enter in a project dashboard and go to rewards. If you are not admin the page is broken. After this PR the page will work again.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)
![imatge](https://github.com/GoteoFoundation/goteo/assets/41389482/8a9d7189-b12b-45aa-896e-65c9bc8bb917)

:hearts: Thank you!
