### PR TITLE
Fix color of non active slick dots in creator

### DIFF
--- a/public/assets/sass/creator.scss
+++ b/public/assets/sass/creator.scss
@@ -33,6 +33,14 @@ body.creator {
         color: $background-light-green;
         cursor: pointer;
       }
+
+      .slick-dots li:not(.slick-active) button::before {
+        color: $background-grey !important;
+      }
+
+      .slick-dots li.slick-acitve button::before {
+        color: $background-light-green !important;
+      }
     }
   }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes https://app.asana.com/0/1206149597772083/1206164190834609/f

#### Testing
Go to the /creator/fundacionplatoniq page and see the slider.

### :camera: Screenshots
![imagen](https://github.com/GoteoFoundation/goteo/assets/61125897/2fd386ab-edc5-4c38-8e13-441584d98b78)