### PR TITLE
Fix/stripe refunds

### DIFF
--- a/src/Goteo/Payment/Method/StripeSubscriptionPaymentMethod.php
+++ b/src/Goteo/Payment/Method/StripeSubscriptionPaymentMethod.php
@@ -68,25 +68,22 @@ class StripeSubscriptionPaymentMethod extends AbstractPaymentMethod
 
     public function purchase(): ResponseInterface
     {
-        $response = $this->getGateway()->purchase([
+        return $this->getGateway()->purchase([
             'invest' => $this->invest,
             'user' => $this->user
         ])->send();
-
-        /** @var Subscription */
-        $subscription = $response->getData();
-
-        $this->invest->setPayment($subscription->id);
-
-        return $response;
     }
 
     public function completePurchase(): ResponseInterface
     {
-        /** @var SubscriptionGateway */
-        $gateway = $this->getGateway();
+        $response = $this->getGateway()->completePurchase();
 
-        return $gateway->completePurchase();
+        /** @var Subscription */
+        $subscription = $response->getData()['subscription'];
+
+        $this->invest->setPayment($subscription->id);
+
+        return $response;
     }
 
     public function refundable(): bool

--- a/src/Goteo/Repository/InvestRepository.php
+++ b/src/Goteo/Repository/InvestRepository.php
@@ -34,4 +34,13 @@ class InvestRepository extends BaseRepository
 
         return $this->query($sql, [$payment])->fetchAll(\PDO::FETCH_CLASS, Invest::class);
     }
+
+    public function getListByTransaction(string $transaction): array
+    {
+        $sql = "SELECT *
+                FROM invest
+                WHERE invest.transaction = ?";
+
+        return $this->query($sql, [$transaction])->fetchAll(\PDO::FETCH_CLASS, Invest::class);
+    }
 }

--- a/src/Omnipay/Stripe/Subscription/Message/DonationResponse.php
+++ b/src/Omnipay/Stripe/Subscription/Message/DonationResponse.php
@@ -2,25 +2,20 @@
 
 namespace Omnipay\Stripe\Subscription\Message;
 
-use Goteo\Application\Config;
 use Omnipay\Common\Message\AbstractResponse;
 use Omnipay\Common\Message\RedirectResponseInterface;
 use Omnipay\Common\Message\RequestInterface;
 use Stripe\Checkout\Session as StripeSession;
-use Stripe\StripeClient;
 
 class DonationResponse extends AbstractResponse implements RedirectResponseInterface
 {
-    private StripeClient $stripe;
-
     private StripeSession $checkout;
 
-    public function __construct(RequestInterface $request, string $checkoutSessionId)
+    public function __construct(RequestInterface $request, StripeSession $checkout)
     {
-        parent::__construct($request, $checkoutSessionId);
+        parent::__construct($request, ['checkout' => $checkout]);
 
-        $this->stripe = new StripeClient(Config::get('payments.stripe.secretKey'));
-        $this->checkout = $this->stripe->checkout->sessions->retrieve($checkoutSessionId);
+        $this->checkout = $checkout;
     }
 
     public function isSuccessful()

--- a/src/Omnipay/Stripe/Subscription/Message/SubscriptionResponse.php
+++ b/src/Omnipay/Stripe/Subscription/Message/SubscriptionResponse.php
@@ -36,4 +36,9 @@ class SubscriptionResponse extends AbstractResponse implements RedirectResponseI
     {
         return $this->checkout->url;
     }
+
+    public function getTransactionReference()
+    {
+        return $this->checkout->invoice;
+    }
 }

--- a/src/Omnipay/Stripe/Subscription/Message/SubscriptionResponse.php
+++ b/src/Omnipay/Stripe/Subscription/Message/SubscriptionResponse.php
@@ -2,25 +2,24 @@
 
 namespace Omnipay\Stripe\Subscription\Message;
 
-use Goteo\Application\Config;
 use Omnipay\Common\Message\AbstractResponse;
 use Omnipay\Common\Message\RedirectResponseInterface;
 use Omnipay\Common\Message\RequestInterface;
 use Stripe\Checkout\Session as StripeSession;
-use Stripe\StripeClient;
+use Stripe\Subscription;
 
 class SubscriptionResponse extends AbstractResponse implements RedirectResponseInterface
 {
-    private StripeClient $stripe;
-
     private StripeSession $checkout;
 
-    public function __construct(RequestInterface $request, string $checkoutSessionId)
-    {
-        parent::__construct($request, $checkoutSessionId);
+    public function __construct(
+        RequestInterface $request,
+        StripeSession $checkout,
+        ?Subscription $subscription = null
+    ) {
+        parent::__construct($request, ['checkout' => $checkout, 'subscription' => $subscription]);
 
-        $this->stripe = new StripeClient(Config::get('payments.stripe.secretKey'));
-        $this->checkout = $this->stripe->checkout->sessions->retrieve($checkoutSessionId);
+        $this->checkout = $checkout;
     }
 
     public function isSuccessful()


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes an issue on the Stripe Gateway that was making it impossible for the invests to be written with the correct reference value, the subscription id, under the `payment` property, making it impossible for the webhook controller to find the referenced invests when receiving a refund event.

It also saves the Stripe invoice id under the `transaction` property, this makes invests be tied 1:1 to an specific stripe invoice (i.e a payment for the subscription).

#### :pushpin: Related Issues
- Fixes https://app.asana.com/0/1206149597772083/1206194873937420

#### Testing
1. Set the stripe-cli to forward webhook events to your localhost.
2. Generate a subscription from Goteo.
3. Check on the /admin board that the new invest has the subscription id and invoice id under the payment and transaction.
4. Make a refund of the payment at the stripe dashboard.
5. Check on the /admin board that the new invest now has an status of "cancelled".

:hearts: Thank you!
