### PR TITLE
Channel Map only shown if configured

### DIFF
--- a/Resources/templates/responsive/admin/channelsection/layout.php
+++ b/Resources/templates/responsive/admin/channelsection/layout.php
@@ -5,7 +5,7 @@ $this->layout('admin/container');
 $this->section('admin-container-head');
 
 ?>
-    <h2><?= $this->text('translator-node_section') ?></h2>
+    <h2><?= $this->text('translator-node_sections') ?></h2>
 
     <?= $this->insert('admin/partials/search_box') ?>
 

--- a/Resources/templates/responsive/channel/call/partials/map.php
+++ b/Resources/templates/responsive/channel/call/partials/map.php
@@ -2,7 +2,7 @@
 
 $section = current($this->channel->getSections('map'));
 
-if($this->projects || $section):
+if($section):
   $config = $this->channel->getConfig();
   $map_config = $config['map'];
   $params = [
@@ -23,8 +23,6 @@ if($this->projects || $section):
   if ($map_config['center']) {
     $url .= '/' . implode(',', $map_config['center']);
   }
-
-
 ?>
 
 <div class="section map">

--- a/src/Goteo/Controller/Admin/ChannelSectionAdminController.php
+++ b/src/Goteo/Controller/Admin/ChannelSectionAdminController.php
@@ -182,7 +182,7 @@ class ChannelSectionAdminController extends AbstractAdminController
             Message::error($e->getMessage());
         }
 
-        return $this->redirect('/admin/channelsections/' . $node);
+        return $this->redirect('/admin/channelsection/' . $node);
     }
 
 }


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

Currently, the map inside the channel call layout is shown if there are projects or if the `NodeSection` is configured. This will change and only be shown when the node section exists.

:hearts: Thank you!
