### PR TITLE
[feat] Antispam forms

### DIFF
--- a/Resources/templates/default/about/contact.php
+++ b/Resources/templates/default/about/contact.php
@@ -52,6 +52,7 @@ $this->layout('layout', [
                                 <div class="field">
                                     <label for="email"><?= $this->text('contact-email-field') ?></label><br />
                                     <input class="short" type="text" id="email" name="email" value="<?= $this->data['email'] ?>"/>
+                                    <?= $this->insert($this->honeypot->template, $this->honeypot->params) ?>
                                 </div>
                             </td>
                         </tr>

--- a/Resources/templates/default/partials/form/honeypot.php
+++ b/Resources/templates/default/partials/form/honeypot.php
@@ -1,0 +1,5 @@
+<label for="<?= $this->trap ?>" style="width: 0px; height: 0px; margin: 0px; padding: 0px; opacity: 0; display: block;">
+    <?= $this->text('contact-email-field') ?>
+</label>
+<br style="width: 0px; height: 0px; margin: 0px; padding: 0px; opacity: 0; display: block;" />
+<input id="<?= $this->trap ?>" name="<?= $this->trap ?>" value="" type="text" class="short" style="width: 0px; height: 0px; margin: 0px; padding: 0px; opacity: 0; display: block;" />

--- a/db/migrations/20240620092323_goteo_form_honeypot.php
+++ b/db/migrations/20240620092323_goteo_form_honeypot.php
@@ -37,7 +37,8 @@ class GoteoFormHoneypot
                 `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
                 `trap` VARCHAR(50) NOT NULL,
                 `prey` TEXT,
-                `template` TEXT,    
+                `template` TEXT,
+                `datetime` TIMESTAMP,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
             ";

--- a/db/migrations/20240620092323_goteo_form_honeypot.php
+++ b/db/migrations/20240620092323_goteo_form_honeypot.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Migration Task class.
+ */
+class GoteoFormHoneypot
+{
+    public function preUp()
+    {
+        // add the pre-migration code here
+    }
+
+    public function postUp()
+    {
+        // add the post-migration code here
+    }
+
+    public function preDown()
+    {
+        // add the pre-migration code here
+    }
+
+    public function postDown()
+    {
+        // add the post-migration code here
+    }
+
+    /**
+     * Return the SQL statements for the Up migration
+     *
+     * @return string The SQL string to execute for the Up migration.
+     */
+    public function getUpSQL()
+    {
+        return "
+            CREATE TABLE `form_honeypot` (
+                `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+                `trap` VARCHAR(50) NOT NULL,
+                `prey` TEXT,
+                `template` TEXT,    
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+            ";
+    }
+
+    /**
+     * Return the SQL statements for the Down migration
+     *
+     * @return string The SQL string to execute for the Down migration.
+     */
+    public function getDownSQL()
+    {
+        return "DROP TABLE `form_honeypot`";
+    }
+}

--- a/src/Goteo/Model/FormHoneypot.php
+++ b/src/Goteo/Model/FormHoneypot.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Goteo\Model;
+
+use Goteo\Core\Model;
+use Symfony\Component\HttpFoundation\Request;
+
+class FormHoneypot extends Model
+{
+    public $id;
+
+    /**
+     * This value should be left blank by humans but non-blank by robots
+     */
+    public $trap;
+
+    /**
+     * This value was, most-likely, introduced by a robot
+     */
+    public $prey;
+
+    public $params;
+
+    /**
+     * The template for the trap field
+     */
+    public $template = 'partials/form/honeypot';
+
+    protected $Table = 'form_honeypot';
+    static protected $Table_static = 'impact_item';
+
+    public function save(&$errors = array())
+    {
+        if (!$this->validate($errors)) return false;
+
+        $this->dbInsertUpdate(['id', 'trap', 'prey', 'template']);
+    }
+
+    public function validate(&$errors = array())
+    {
+        if (empty($errors))
+            return true;
+        else
+            return false;
+    }
+
+    /**
+     * Get a trapped form field that is invisible to humans and juicy for robots to fill
+     */
+    public static function layTrap()
+    {
+        $honeypot = new FormHoneypot;
+        $honeypot->trap = "email_addr_confirm";
+        $honeypot->prey = "";
+        $honeypot->params = [
+            'trap' => $honeypot->trap,
+            'prey' => $honeypot->prey
+        ];
+
+        return $honeypot;
+    }
+
+    /**
+     * Checks if something got caught in the trap
+     * @return bool `true` if caught something, `false` if not
+     */
+    public static function checkTrap(string $trap, $data): bool
+    {
+        if ($data instanceof Request) {
+            return $data->request->get($trap) !== "";
+        }
+        
+        return false;
+    }
+}

--- a/src/Goteo/Model/FormHoneypot.php
+++ b/src/Goteo/Model/FormHoneypot.php
@@ -29,7 +29,7 @@ class FormHoneypot extends Model
     /**
      * The date at wich the trap was laid
      */
-    public $date;
+    public $datetime;
 
     protected $Table = 'form_honeypot';
     static protected $Table_static = 'form_honeypot';
@@ -38,7 +38,7 @@ class FormHoneypot extends Model
     {
         if (!$this->validate($errors)) return false;
 
-        $this->dbInsertUpdate(['id', 'trap', 'prey', 'template']);
+        $this->dbInsertUpdate(['id', 'trap', 'prey', 'template', 'datetime']);
     }
 
     public function validate(&$errors = array())
@@ -57,7 +57,7 @@ class FormHoneypot extends Model
         $honeypot = new FormHoneypot;
         $honeypot->trap = "email_addr_confirm";
         $honeypot->prey = "";
-        $honeypot->date = new \DateTime();
+        $honeypot->datetime = new \DateTime();
         $honeypot->params = [
             'trap' => $honeypot->trap,
             'prey' => $honeypot->prey

--- a/src/Goteo/Model/FormHoneypot.php
+++ b/src/Goteo/Model/FormHoneypot.php
@@ -26,8 +26,13 @@ class FormHoneypot extends Model
      */
     public $template = 'partials/form/honeypot';
 
+    /**
+     * The date at wich the trap was laid
+     */
+    public $date;
+
     protected $Table = 'form_honeypot';
-    static protected $Table_static = 'impact_item';
+    static protected $Table_static = 'form_honeypot';
 
     public function save(&$errors = array())
     {
@@ -52,6 +57,7 @@ class FormHoneypot extends Model
         $honeypot = new FormHoneypot;
         $honeypot->trap = "email_addr_confirm";
         $honeypot->prey = "";
+        $honeypot->date = new \DateTime();
         $honeypot->params = [
             'trap' => $honeypot->trap,
             'prey' => $honeypot->prey


### PR DESCRIPTION
#### :tophat: What? Why?
Adds trap fields in forms that are invisible to humans and as such will be left blank by them, but that robots might fill.

#### :pushpin: Related Issues
https://app.asana.com/0/1205580187188381/1207505525955578

#### Testing
1. Update your DB: `migrate up`
2. Go to the `/contact` form.
3. The field is hidden below the regular email input. You can reach it by hitting the `Tab` key once when focused on the email input field. Introduce any value.
4. Application will present you with a regular success message. But if you check MailHog nothing should show up. `select * from form_honeypot;` should show a new record with the value you previously introduced.

:hearts: Thank you!
