### PR TITLE
[FIX] Sizing of honeypot input fields not true 0

### DIFF
--- a/Resources/templates/default/partials/form/honeypot.php
+++ b/Resources/templates/default/partials/form/honeypot.php
@@ -1,5 +1,9 @@
-<label for="<?= $this->trap ?>" style="width: 0px; height: 0px; margin: 0px; padding: 0px; opacity: 0; display: block;">
+<?php
+$style_hidden = "width: 0px; height: 0px; margin: 0px; padding: 0px; border: 0px; opacity: 0; display: block;"
+?>
+
+<label for="<?= $this->trap ?>" style="<?= $style_hidden ?>">
     <?= $this->text('contact-email-field') ?>
 </label>
-<br style="width: 0px; height: 0px; margin: 0px; padding: 0px; opacity: 0; display: block;" />
-<input id="<?= $this->trap ?>" name="<?= $this->trap ?>" value="" type="text" class="short" style="width: 0px; height: 0px; margin: 0px; padding: 0px; opacity: 0; display: block;" />
+<br style="<?= $style_hidden ?>" />
+<input id="<?= $this->trap ?>" name="<?= $this->trap ?>" value="" type="text" class="short" style="<?= $style_hidden ?>" />


### PR DESCRIPTION
#### :tophat: What? Why?
After careful observation it was discovered the honeypot input field was not of size 0, but it actually had a 1px border that made it take a total of 2px in the form. Making the true email input above it very slightly out of grid. This PR fixes the error and unifies the styling for the rest of the invisible honeypot HTML elements.

:hearts: Thank you!
