### PR TITLE
Fix transactions id in payments to pool

### DIFF
--- a/src/Goteo/Payment/Method/PaypalPaymentMethod.php
+++ b/src/Goteo/Payment/Method/PaypalPaymentMethod.php
@@ -28,9 +28,11 @@ class PaypalPaymentMethod extends AbstractPaymentMethod
         /** @var ExpressGateway */
         $gateway = $this->getGateway();
         $invest = $this->getInvest();
-        $project = Project::get($invest->project);
-        $transactionId = sprintf("%s-%s", $project->getNumericId(), $invest->id);
-
+        $transactionId = $invest->id;
+        if ($invest->project) {
+            $project = Project::get($invest->project);
+            $transactionId = sprintf("%s-%s", $project->getNumericId(), $invest->id);
+        }
         $invest->setPreapproval($transactionId);
 
         // You can specify your paypal gateway details in config/settings.yml

--- a/src/Goteo/Payment/Method/PaypalPaymentMethod.php
+++ b/src/Goteo/Payment/Method/PaypalPaymentMethod.php
@@ -28,11 +28,13 @@ class PaypalPaymentMethod extends AbstractPaymentMethod
         /** @var ExpressGateway */
         $gateway = $this->getGateway();
         $invest = $this->getInvest();
-        $transactionId = $invest->id;
+
+        $transactionId = sprintf("0000000000-%s", $invest->id);
         if ($invest->project) {
             $project = Project::get($invest->project);
             $transactionId = sprintf("%s-%s", $project->getNumericId(), $invest->id);
         }
+
         $invest->setPreapproval($transactionId);
 
         // You can specify your paypal gateway details in config/settings.yml

--- a/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
+++ b/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
@@ -38,11 +38,8 @@ class SubscriptionRequest extends AbstractRequest
         $user = $data['user'];
         $invest = $data['invest'];
 
-        /** @var Project */
-        $project = $invest->getProject();
-
         $customer = $this->getStripeCustomer($user)->id;
-        $metadata = $this->getMetadata($project, $invest, $user);
+        $metadata = $this->getMetadata($invest);
 
         $successUrl = sprintf('%s?session_id={CHECKOUT_SESSION_ID}', $this->getRedirectUrl(
             'invest',
@@ -166,18 +163,7 @@ class SubscriptionRequest extends AbstractRequest
 
     private function getStripeProduct(Invest $invest): Product
     {
-        /** @var User */
-        $user = $invest->getUser();
-
-        /** @var Project */
-        $project = $invest->getProject();
-
-        $productId = sprintf(
-            '%s_%s_%s',
-            $project->id,
-            $this->getInvestReward($invest, 'noreward'),
-            $user->id,
-        );
+        $productId = $this->getProductId($invest);
 
         try {
             return $this->stripe->products->retrieve($productId);
@@ -196,14 +182,54 @@ class SubscriptionRequest extends AbstractRequest
         }
     }
 
-    private function getMetadata(Project $project, Invest $invest, User $user): array
+    private function getMetadata(Invest $invest): array
     {
+        /** @var Project */
+        $project = $invest->getProject();
+        /** @var User */
+        $user = $invest->getUser();
+
+        $projectId = ($project) ? $project->id : null;
+
         return [
             'donate_amount' => $invest->donate_amount,
-            'project' => $project->id,
+            'project' => $projectId,
             'invest' => $invest->id,
             'reward' => $this->getInvestReward($invest, ''),
             'user' => $user->id,
         ];
+    }
+
+    private function getProductId(Invest $invest): string
+    {
+        if ($project = $invest->getProject())
+            return $this->getProductWithProjectId($invest, $project);
+
+        return $this->getProductWithoutProjectId($invest);
+    }
+
+    private function getProductWithProjectId(Invest $invest, Project $project): string
+    {
+        /** @var User */
+        $user = $invest->getUser();
+
+        return sprintf(
+            '%s_%s_%s',
+            $project->id,
+            $this->getInvestReward($invest, 'noreward'),
+            $user->id,
+        );
+    }
+
+    private function getProductWithoutProjectId(Invest $invest): string
+    {
+        /** @var User */
+        $user = $invest->getUser();
+
+        return sprintf(
+            '%s_%s',
+            $invest->id,
+            $user->id
+        );
     }
 }

--- a/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
+++ b/src/Omnipay/Stripe/Subscription/Message/SubscriptionRequest.php
@@ -43,7 +43,7 @@ class SubscriptionRequest extends AbstractRequest
 
         $successUrl = sprintf('%s?session_id={CHECKOUT_SESSION_ID}', $this->getRedirectUrl(
             'invest',
-            $project->id,
+            $metadata['project'],
             $invest->id,
             'complete'
         ));
@@ -168,11 +168,16 @@ class SubscriptionRequest extends AbstractRequest
         try {
             return $this->stripe->products->retrieve($productId);
         } catch (\Stripe\Exception\InvalidRequestException $e) {
-            $productDescription = sprintf(
-                '%s - %s',
-                $project->name,
-                $this->getInvestReward($invest, Text::get('invest-resign'))
-            );
+            if ($project = $invest->getProject()) {
+                $productDescription = sprintf(
+                    '%s - %s',
+                    $project->name,
+                    $this->getInvestReward($invest, Text::get('invest-resign'))
+                );
+            } else {
+                $productDescription = Text::get('invest-pool-method');
+            }
+
 
             return $this->stripe->products->create([
                 'id' => $productId,


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
Fix a bug in the donation process to the wallet of the user. Since the upgrade to use the project id in the metadata of the transactions inside the different payment providers, we are facing this bug that does not allow users to donate to their own wallet.

:hearts: Thank you!
