### PR TITLE
Fix node project get list return type

### DIFF
--- a/src/Goteo/Model/Node/NodeProject.php
+++ b/src/Goteo/Model/Node/NodeProject.php
@@ -27,7 +27,7 @@ class NodeProject extends Model {
     /**
      * @return NodeProject[]
      */
-    static public function getList(array $filters = [], int $offset = 0, int $limit = 10, bool $count = false, string $lang = null): array
+    static public function getList(array $filters = [], int $offset = 0, int $limit = 10, bool $count = false, string $lang = null)
     {
         $filter = [];
         $values = [];

--- a/src/Goteo/Model/Node/NodeProject.php
+++ b/src/Goteo/Model/Node/NodeProject.php
@@ -25,7 +25,7 @@ class NodeProject extends Model {
     }
 
     /**
-     * @return NodeProject[]
+     * @return NodeProject[] | int
      */
     static public function getList(array $filters = [], int $offset = 0, int $limit = 10, bool $count = false, string $lang = null)
     {


### PR DESCRIPTION
#### :tophat: What? Why?
The return type in node project get list does not follow the actual content of the function. It can return an array or a integer, depending on the $count boolean. If we had an updated php version then we could make a union type return 

The change in the return type made the NodeProject controller not accessible because it was broken.

:hearts: Thank you!
