### PR TITLE
[fix] $dataSets variable naming

### DIFF
--- a/Resources/templates/responsive/channel/layout.php
+++ b/Resources/templates/responsive/channel/layout.php
@@ -77,8 +77,8 @@ $background = $this->channel->owner_background;
 
 <?php endif; ?>
 
-<?php if ($dataSetsSection = $this->nodeSections['data_sets']): ?>
-    <?= $this->insert("channel/partials/data_sets", ['dataSetsSection' => $dataSetsSection]); ?>
+<?php if ($dataSets = $this->nodeSections['data_sets']): ?>
+    <?= $this->insert("channel/partials/data_sets", ['dataSets' => $dataSets]); ?>
 <?php endif; ?>
 
 <?= $this->insert("channel/partials/posts_section") ?>

--- a/Resources/templates/responsive/channel/layout.php
+++ b/Resources/templates/responsive/channel/layout.php
@@ -77,8 +77,8 @@ $background = $this->channel->owner_background;
 
 <?php endif; ?>
 
-<?php if ($dataSets = $this->nodeSections['data_sets']): ?>
-    <?= $this->insert("channel/partials/data_sets", ['dataSets' => $dataSets]); ?>
+<?php if ($dataSetsSection = $this->nodeSections['data_sets']): ?>
+    <?= $this->insert("channel/partials/data_sets", ['dataSetsSection' => $dataSetsSection]); ?>
 <?php endif; ?>
 
 <?= $this->insert("channel/partials/posts_section") ?>

--- a/src/Goteo/Controller/ChannelController.php
+++ b/src/Goteo/Controller/ChannelController.php
@@ -190,6 +190,9 @@ class ChannelController extends Controller {
 
         $view= $channel->type=='normal' ? 'channel/list_projects' : 'channel/'.$channel->type.'/list_projects';
 
+        $dataSetsRepository = new DataSetRepository();
+        $dataSets = $dataSetsRepository->getListByChannel([$id]);
+
         return $this->viewResponse(
             $view,
             [
@@ -198,7 +201,8 @@ class ChannelController extends Controller {
                 'title_text' => $title_text,
                 'type' => $type,
                 'total' => $total,
-                'limit' => $limit
+                'limit' => $limit,
+                'dataSets' => $dataSets
             ]
         );
     }


### PR DESCRIPTION
#### :tophat: What? Why?
Template at `Resources/templates/responsive/partials/components/data_sets.php` was expecting to be injected a `dataSets` prop to walk via foreach. However in `Resources/templates/responsive/channel/layout.php` this template was being inserted with no `dataSets` prop, instead it was being inserted with a `dataSetsSection` prop, which caused the foreach loop to fail with an `Invalid argument` error.

#### Testing
This error was being triggered mainly at /channel/feminismos/social-account-telegram. Call to this address, check that the Invalid argument error appears in your logs, then call this address with the updated code and the error will not appear anymore.

:hearts: Thank you!
