### PR TITLE
Improve robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,20 @@
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-Agent: ImagesiftBot
+Crawl-delay: 60
+
 User-agent: *
 Disallow: /admin
 Disallow: /admin/
 Disallow: /dashboard/
+


### PR DESCRIPTION
#### :tophat: What? Why?
This past week we have experienced lots of traffic comming from some bots that are reported to be taking down websites because of their aggressive behaviour.

This PR changes the robots.txt in goteo to disallow the robots of OpenAI (even though there are proves that it does not follow it), and Amazonbot, as well as other marketing tools.

:hearts: Thank you!
