### PR TITLE
[fix] report table raw invests

### DIFF
--- a/Resources/templates/default/admin/projects/report.php
+++ b/Resources/templates/default/admin/projects/report.php
@@ -6,6 +6,7 @@
     'project' => $this->project,
     'account' => $this->account,
     'contract' => $this->contract,
+    'invests' => $this->invests,
     'Data' => $this->data,
     'admin' => true
 ]) ?>

--- a/Resources/templates/legacy/project/invests_table.html.php
+++ b/Resources/templates/legacy/project/invests_table.html.php
@@ -8,25 +8,53 @@ if (!$account->vat) {
 
 $projectFee = round($account->fee / 100, 2);
 
-$tpvTotal = $vars['Data']['tpv']['total']['amount'];
+function countTotal($invests, $method)
+{
+    $count = 0;
+
+    foreach ($invests as $invest) {
+        if ($invest->status < 1) continue;
+        if ($invest->method !== $method) continue;
+
+        $total = $count + 1;
+    }
+
+    return $total;
+}
+
+function calcTotal($invests, $method)
+{
+    $total = 0;
+
+    foreach ($invests as $invest) {
+        if ($invest->status < 1) continue;
+        if ($invest->method !== $method) continue;
+
+        $total = $total + $invest->amount;
+    }
+
+    return $total;
+}
+
+$tpvTotal = calcTotal($vars['invests'], 'tpv');
 $tpvProjectFee = $tpvTotal * $projectFee;
 $tpvProjectVat = $tpvProjectFee * 0.21;
 $tpvGatewayFee = $tpvTotal  * 0.008;
 $tpvGatewayVat = 0;
 
-$paypalTotal = $vars['Data']['paypal']['total']['amount'];
+$paypalTotal = calcTotal($vars['invests'], 'paypal');
 $paypalProjectFee = $paypalTotal * $projectFee;
 $paypalProjectVat = $paypalProjectFee * 0.21;
-$paypalGatewayFee = ($paypalTotal * 0.034) + ($vars['Data']['paypal']['total']['invests'] * 0.35);
+$paypalGatewayFee = ($paypalTotal * 0.034) + (countTotal($vars['invests'], 'paypal') * 0.35);
 $paypalGatewayVat = 0;
 
-$poolTotal = $vars['Data']['pool']['total']['amount'];
+$poolTotal = calcTotal($vars['invests'], 'pool');
 $poolProjectFee = $poolTotal * $projectFee;
 $poolProjectVat = $poolProjectFee * 0.21;
 $poolGatewayFee = $poolTotal * 0.02;
 $poolGatewayVat = $poolGatewayFee * 0.21;
 
-$cashTotal = $vars['Data']['cash']['total']['amount'];
+$cashTotal = calcTotal($vars['invests'], 'cash');
 $cashProjectFee = $cashTotal * $projectFee;
 $cashProjectVat = $cashProjectFee * 0.21;
 $cashGatewayFee = $cashTotal * 0.02;
@@ -50,7 +78,7 @@ $reportData = [
         'base' => \amount_format($paypalTotal, 2),
         'project_fee' => sprintf("%s (%s%%)", \amount_format($paypalProjectFee, 2), $account->fee),
         'project_vat' => sprintf("%s (21%%)", \amount_format($paypalProjectVat, 2)),
-        'gateway_fee' => sprintf("%s (3,4%% + 0,35 * trx)", \amount_format($paypalGatewayFee, 2)),
+        'gateway_fee' => sprintf("%s (3,4%% + 0,35 * trxs)", \amount_format($paypalGatewayFee, 2)),
         'gateway_vat' => sprintf("%s (21%%)", \amount_format($paypalGatewayVat, 2))
     ],
     'MONEDERO' => [

--- a/Resources/templates/legacy/project/report.html.php
+++ b/Resources/templates/legacy/project/report.html.php
@@ -276,7 +276,7 @@ $cName = "P-{$cNum}-{$cDate}";
             </tr>
         </table>
         <br />
-        <?= Goteo\Core\View::get('project/report_table.html.php',  $vars) ?>
+        <?= Goteo\Core\View::get('project/invests_table.html.php',  $vars) ?>
         <br />
     <?php endif; ?>
 

--- a/src/Goteo/Controller/Admin/ProjectsSubController.php
+++ b/src/Goteo/Controller/Admin/ProjectsSubController.php
@@ -207,12 +207,14 @@ class ProjectsSubController extends AbstractSubController {
         $data = Model\Invest::getReportData($project->id, $project->status, $project->round, $project->passed);
         $account = Model\Project\Account::get($project->id);
         $contract = Model\Contract::get($project->id);
+        $invests = Model\Invest::getAll($project->id);
 
         return array(
                 'template' => 'admin/projects/report',
                 'project' => $project,
                 'account' => $account,
                 'contract' => $contract,
+                'invests' => $invests,
                 'data' => $data
         );
     }


### PR DESCRIPTION
#### :tophat: What? Why?
The project report table wasn't working for projects in non-funded status. The issue was in how the project report was pulling data. Since the table is to easy admin's work while checking project numbers at any point of a project's lifecycle the table does not care about the case handling in the report generation, it only needs the project's invests data.

#### :pushpin: Related Issues
- Related to #621 
- Fixes missing data on report for projects with no finished financed.

#### Testing
Go to the report page for any project in status `4`, or any other non conventional status, and check that the report tables still shows invests data.

:hearts: Thank you!
