### PR TITLE
Register button disable if maxmind database is not configured

### DIFF
--- a/src/Goteo/Model/Location/LocationItem.php
+++ b/src/Goteo/Model/Location/LocationItem.php
@@ -158,6 +158,10 @@ abstract class LocationItem extends \Goteo\Core\Model implements LocationInterfa
      */
     static public function createByIp($id, $ip){
         $cities = Config::get('geolocation.maxmind.cities');
+        
+        if (!$cities)
+            return false;
+        
         try {
             // This creates the Reader object, which should be reused across lookups.
             $reader = new \GeoIp2\Database\Reader($cities);


### PR DESCRIPTION
If maxmind database is not configured it  causes an exception in register form which causes js scripts not to load and when check the accept policy checkbox the register button not enabled.

![image](https://github.com/user-attachments/assets/aecfb04a-f148-4d78-b439-246f915ce5f3)
