### PR TITLE
Improve use of project currency

### DIFF
--- a/Resources/templates/responsive/project/home.php
+++ b/Resources/templates/responsive/project/home.php
@@ -48,8 +48,8 @@
                                       <strong><?= $cost->name ?></strong>
                                       <div><?= $cost->description ?></div>
                                   </td>
-                                  <td class="text-center text-nowrap"><span class="required"><?= amount_format($cost->min) ?></span></td>
-                                  <td class="text-center text-nowrap"><?= !$cost->min ? amount_format($cost->opt) : '' ?></td>
+                                  <td class="text-center text-nowrap"><span class="required"><?= amount_format($cost->min, 0, false, false, true, $project->currency) ?></span></td>
+                                  <td class="text-center text-nowrap"><?= !$cost->min ? amount_format($cost->opt, 0, false, false, true, $project->currency) : '' ?></td>
                                 </tr>
                                 <?php if(end($this->costs)==$list&&end($list)==$cost): ?>
                                     <tr>
@@ -58,10 +58,10 @@
                                         </td>
 
                                         <td class="text-center text-nowrap" data-type="html" data-breakpoints="xs">
-                                            <span class="required"><?= amount_format($project->mincost) ?></span>
+                                            <span class="required"><?= amount_format($project->mincost, 0, false, false, true, $project->currency) ?></span>
                                         </td>
                                         <td class="text-center text-nowrap" data-type="html" data-breakpoints="xs">
-                                            <?= amount_format($project->maxcost) ?>
+                                            <?= amount_format($project->maxcost, 0, false, false, true, $project->currency) ?>
                                         </td>
                                     </tr>
                                 <?php endif ?>

--- a/Resources/templates/responsive/project/partials/meter.php
+++ b/Resources/templates/responsive/project/partials/meter.php
@@ -160,19 +160,19 @@ use Goteo\Library\Check;
             <?= $this->text('project-view-metter-got') ?>
         </div>
         <div class="reached">
-            <?= amount_format($project->amount) ?>
+            <?= amount_format($project->amount, 0, false, false, true) ?>
         </div>
         <div class="optimum-label">
             <?= $this->text('project-view-metter-optimum') ?>
         </div>
         <div class="optimum">
-            <?= amount_format($project->maxcost) ?>
+            <?= amount_format($project->maxcost, 0, false, false, true, $project->currency) ?>
         </div>
         <div class="minimum-label">
             <?= $this->text('project-view-metter-minimum') ?>
         </div>
         <div class="minimum">
-            <?= amount_format($project->mincost) ?>
+            <?= amount_format($project->mincost, 0, false, false, true, $project->currency) ?>
         </div>
     </div>
 </div>

--- a/Resources/templates/responsive/project/partials/responsive_meter.php
+++ b/Resources/templates/responsive/project/partials/responsive_meter.php
@@ -121,7 +121,7 @@ use Goteo\Library\Check;
                 <?= $this->text('project-view-metter-minimum') ?>
                 </div>
                 <div class="opt-min">
-                <?= amount_format($project->mincost) ?>
+                <?= amount_format($project->mincost, 0, false, false, true, $project->currency) ?>
                 </div>
             </div>
             <div class="item">
@@ -129,7 +129,7 @@ use Goteo\Library\Check;
                 <?= $this->text('project-view-metter-optimum') ?>
                 </div>
                 <div class="opt-min">
-                <?= amount_format($project->maxcost) ?>
+                <?= amount_format($project->maxcost, 0, false, false, true, $project->currency) ?>
                 </div>
             </div>
         </div>

--- a/src/Goteo/Application/Currency.php
+++ b/src/Goteo/Application/Currency.php
@@ -125,7 +125,7 @@ class Currency {
      *
      *  requires a Converter instance
      */
-    static public function amountFormat($amount, $decs = 0, $nosymbol = false, $revert = false, $format = true) {
+    static public function amountFormat($amount, $decs = 0, $nosymbol = false, $revert = false, $format = true, $current_currency = null) {
 
         // check odd behaviour
         if (!is_float($amount) && !is_numeric($amount)) {
@@ -139,6 +139,12 @@ class Currency {
         // currency data (htmnl, name, thous/decs)
         $ccy = static::$currencies[$currency];
 
+        // default -> EUR, project_currency -> USD/MXN
+        if ($current_currency) {
+            $default = $current_currency;
+        }
+
+        // session -> EUR, default -> USD
         if ($currency != $default) {
             $rates = $converter->getRates($default);
             $amount = round($revert ? $amount / $rates[$currency] : $amount * $rates[$currency]);

--- a/src/Goteo/Core/Helpers.php
+++ b/src/Goteo/Core/Helpers.php
@@ -170,9 +170,9 @@ namespace {
     /**
      * Numberformat para convertir importes
      */
-    function amount_format($amount, $decs = 0, $nosymbol = false, $revert = false, $format = true) {
+    function amount_format($amount, $decs = 0, $nosymbol = false, $revert = false, $format = true, $current_currency = null) {
 
-        return Currency::amountFormat($amount, $decs, $nosymbol, $revert, $format);
+        return Currency::amountFormat($amount, $decs, $nosymbol, $revert, $format, $current_currency);
     }
 
     /**


### PR DESCRIPTION
#### :tophat: What? Why?

The project can set it's own base currency, but when the cost are being calculated, the base currency of the platform is used, therefore creating a problem in the logic of the minimum and optimal amounts of the project.

This PR adds the possibility to correctly calculate the minimum and optimum of the project based on the project currency and the session of the user when navigating in the project.

:hearts: Thank you!
